### PR TITLE
update sqlite-jdbc version

### DIFF
--- a/iast-java/pom.xml
+++ b/iast-java/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.21.0.1</version>
+            <version>3.36.0.3</version>
         </dependency>
         <!--redis-->
         <dependency>


### PR DESCRIPTION
The version 3.21.0.1 of sqlite-jdbc will throw an error on Mac M1, upgrading to version 3.36.0.3 resolves the issue.