### PR TITLE
fix:Resolved bugs with bean duplicate naming and single test not bein…

### DIFF
--- a/iast-java/src/main/java/com/iast/astbenchmark/cases/engine/accuracy/trackTaintObject/fieldOrItemLevel/partItemHasTaint/AccuracyTrackTaintObject_SerializeDeSerialize_002_F.java
+++ b/iast-java/src/main/java/com/iast/astbenchmark/cases/engine/accuracy/trackTaintObject/fieldOrItemLevel/partItemHasTaint/AccuracyTrackTaintObject_SerializeDeSerialize_002_F.java
@@ -61,7 +61,7 @@ public class AccuracyTrackTaintObject_SerializeDeSerialize_002_F
 
     @Override
     public IastTestCaseDescriptor followIastTestCaseDescriptor() {
-        return new AccuracyTrackTaintObject_SerializeDeSerialize_001_T();
+        return new AccuracyTrackTaintObject_SerializeDeSerialize_003_T();
     }
 
     @Override

--- a/iast-java/src/main/java/com/iast/astbenchmark/cases/engine/accuracy/trackTaintObject/fieldOrItemLevel/partItemHasTaint/AccuracyTrackTaintObject_SerializeDeSerialize_003_T.java
+++ b/iast-java/src/main/java/com/iast/astbenchmark/cases/engine/accuracy/trackTaintObject/fieldOrItemLevel/partItemHasTaint/AccuracyTrackTaintObject_SerializeDeSerialize_003_T.java
@@ -29,7 +29,7 @@ import com.iast.astbenchmark.common.utils.JDKSerializationUtil;
 // compose = AccuracyTrackTaintObject_SerializeDeSerialize_001_T.java && !AccuracyTrackTaintObject_SerializeDeSerialize_002_F.java
 // bind_url = /case00131
 // assession information end
-public class AccuracyTrackTaintObject_SerializeDeSerialize_001_T
+public class AccuracyTrackTaintObject_SerializeDeSerialize_003_T
     implements IastTestCaseDescriptor, IastTestCasePayloadProvider {
 
     /**

--- a/iast-java/src/main/java/com/iast/astbenchmark/cli/test/AutoRunTest.java
+++ b/iast-java/src/main/java/com/iast/astbenchmark/cli/test/AutoRunTest.java
@@ -37,7 +37,7 @@ public class AutoRunTest {
             CopyTestCaseForRun.url_root = url;
         }
         try {
-            Method method = clazz.getMethod(metheodName);
+            Method method = clazz.getDeclaredMethod(metheodName);
             method.setAccessible(true);
             method.invoke(clazz.newInstance());
         } catch (NoSuchMethodException e) {


### PR DESCRIPTION
iast的case中有重名文件。
在跑单个测试用例时使用getMethod无法获取case方法