### PR TITLE
feat: 新增 sast-php 引擎能力评测靶场 (290 case)

### DIFF
--- a/sast-php/README.md
+++ b/sast-php/README.md
@@ -1,0 +1,200 @@
+# SAST-PHP Benchmark — PHP 污点追踪引擎能力评测靶场
+
+## 概述
+
+| 指标 | 数值 |
+|------|------|
+| 总 case 数 | 290 个 PHP 文件 |
+| 准确度 (accuracy) | 64 |
+| 完整度 (completeness) | 226 |
+| T (true positive) | 145 |
+| F (false positive) | 145 |
+| PHP 版本要求 | >= 8.1 |
+
+## 目录结构
+
+```
+sast-php/case/
+├── accuracy/                          # 准确度 — 引擎区分真/假阳性的能力
+│   ├── context_sensitive/             # 上下文敏感
+│   │   ├── multi_invoke/              # 多次调用 (4)
+│   │   ├── polymorphism/              # 多态 (4)
+│   │   └── argument_return_value_passing/  # 参数/返回值传递 (8)
+│   ├── path_sensitive/                # 路径敏感
+│   │   ├── loop_conditional_stmt/     # 条件循环语句 (6)
+│   │   ├── explicit_jump_control/     # 跳转语句 (4)
+│   │   └── exception_throw/           # 异常抛出路径 (4)
+│   ├── flow_sensitive/                # 流敏感
+│   │   ├── normal_stmt/               # 普通语句 (4)
+│   │   └── loop_stmt/                 # 循环语句 (4)
+│   └── object_field_sensitive/        # 对象/域敏感
+│       ├── class_field/               # 类字段 (6)
+│       ├── field_len/                 # 域长度 (6)
+│       ├── one_collection/            # 一维集合 (6)
+│       ├── multidimensional_collection/  # 多维集合 (4)
+│       └── object_sensitive/          # 对象敏感 (4)
+└── completeness/                      # 完整度 — 引擎跟踪污点传播的完备性
+    ├── single_app_tracing/            # 单应用追踪
+    │   ├── alias/                     # 别名 + 引用赋值 (6)
+    │   ├── control_flow/              # 控制流 (10)
+    │   ├── cross_file_package_namespace/  # 跨文件 (56 files, 28 cases)
+    │   ├── datatype/                  # 数据类型 + 超全局变量 (20)
+    │   ├── exception_error/           # 异常处理 (4)
+    │   ├── expression/                # 表达式 (34)
+    │   ├── function_call/             # 函数调用 (40)
+    │   ├── class/                     # 类与对象 (28)
+    │   └── variable_scope/            # 变量作用域 (10)
+    └── dynamic_tracing/               # 动态追踪
+        ├── eval/                      # eval (4)
+        ├── variable_variables/        # 可变变量 (4)
+        └── compact_extract/           # compact/extract (4)
+```
+
+## 评价体系
+
+### accuracy（准确度）— 64 case
+
+| # | 子维度 | 评价项 | T | F | 说明 |
+|---|--------|--------|---|---|------|
+| 1 | context_sensitive/multi_invoke | 准确度->上下文敏感->多次调用 | 2 | 2 | 同一函数多次调用，区分污染/安全参数的返回值 |
+| 2 | context_sensitive/polymorphism | 准确度->上下文敏感->多态 | 2 | 2 | 抽象类/接口多态，子类实现传递或净化污点 |
+| 3 | context_sensitive/argument_return_value_passing | 准确度->上下文敏感->参数/返回值传递 | 4 | 4 | 参数值传递、返回值传递、多层参数/返回值链 |
+| 4 | path_sensitive/loop_conditional_stmt | 准确度->路径敏感->条件循环语句 | 3 | 3 | if/while/if-else 分支中的污点路径区分 |
+| 5 | path_sensitive/explicit_jump_control | 准确度->路径敏感->跳转语句 | 2 | 2 | break/return/continue 对污点传播路径的影响 |
+| 6 | path_sensitive/exception_throw | 准确度->路径敏感->异常抛出 | 2 | 2 | try/catch 块中异常前后的污点传播 |
+| 7 | flow_sensitive/normal_stmt | 准确度->流敏感->普通语句 | 2 | 2 | 赋值顺序、变量覆盖对污点的影响 |
+| 8 | flow_sensitive/loop_stmt | 准确度->流敏感->循环语句 | 2 | 2 | for/while/foreach 循环体内语句执行顺序 |
+| 9 | object_field_sensitive/class_field | 准确度->对象域敏感->类字段 | 3 | 3 | 类字段赋值、getter/setter、嵌套类字段 |
+| 10 | object_field_sensitive/field_len | 准确度->对象域敏感->域长度 | 3 | 3 | 2~4 层嵌套对象字段访问路径 |
+| 11 | object_field_sensitive/one_collection | 准确度->对象域敏感->一维集合 | 3 | 3 | 数组索引、关联数组 key、array_push |
+| 12 | object_field_sensitive/multidimensional_collection | 准确度->对象域敏感->多维集合 | 2 | 2 | 二维数组、嵌套关联数组 |
+| 13 | object_field_sensitive/object_sensitive | 准确度->对象域敏感->对象敏感 | 2 | 2 | 同类不同对象实例区分 |
+
+### completeness/single_app_tracing（完整度-单应用追踪）— 214 case
+
+| # | 子维度 | 评价项 | T | F | 说明 | PHP 特有 |
+|---|--------|--------|---|---|------|----------|
+| 14 | alias | 完整度->单应用追踪->别名 | 3 | 3 | 普通变量赋值、引用赋值 `&$var`、unset 引用 | `&$var` |
+| 15 | control_flow/conditional_stmt | 完整度->单应用追踪->控制流 | 3 | 3 | if/switch/match 分支 | `match` (PHP 8) |
+| 16 | control_flow/loop_stmt | 完整度->单应用追踪->控制流 | 2 | 2 | for/foreach/while 循环 | — |
+| 17 | cross_file: include/require | 完整度->单应用追踪->跨文件 | 2 | 2 | include/require 引入外部函数/类 | — |
+| 18 | cross_file: require_once | 完整度->单应用追踪->跨文件 | 2 | 2 | require_once 引入函数/类 | — |
+| 19 | cross_file: namespace/use | 完整度->单应用追踪->跨文件 | 2 | 2 | 命名空间 + use/use as | `namespace` |
+| 20 | cross_file: autoload | 完整度->单应用追踪->跨文件 | 2 | 2 | spl_autoload_register 自动加载 | `spl_autoload_register` |
+| 21 | cross_file: trait (跨文件) | 完整度->单应用追踪->跨文件 | 2 | 2 | 独立文件定义 trait，use 后调用 | `trait` |
+| 22 | cross_file: interface (跨文件) | 完整度->单应用追踪->跨文件 | 2 | 2 | 独立文件定义接口，实现类调用 | — |
+| 23 | cross_file: inheritance (跨文件) | 完整度->单应用追踪->跨文件 | 2 | 2 | 独立文件定义父类/抽象类，子类继承 | — |
+| 24 | datatype: string | 完整度->单应用追踪->数据类型 | 2 | 2 | 字符串拼接、substr 截取、常量覆盖、str_replace | — |
+| 25 | datatype: array | 完整度->单应用追踪->数据类型 | 2 | 2 | 数组元素存取、array_push/pop、安全 key | — |
+| 26 | datatype: int | 完整度->单应用追踪->数据类型 | 1 | 1 | 整数转字符串拼接、纯整数运算 | — |
+| 27 | datatype: superglobal | 完整度->单应用追踪->数据类型 | 5 | 5 | $_POST/$_COOKIE/$_REQUEST/$_SERVER/$_SESSION | 超全局变量 |
+| 28 | exception_error | 完整度->单应用追踪->异常处理 | 2 | 2 | try/catch/finally 块中污点传播 | — |
+| 29 | expression: basic | 完整度->单应用追踪->表达式 | 2 | 2 | 赋值、拼接 | — |
+| 30 | expression: conditional | 完整度->单应用追踪->表达式 | 2 | 2 | 三元运算符、null 合并 `??` | `??` |
+| 31 | expression: string_interpolation | 完整度->单应用追踪->表达式 | 2 | 2 | 双引号插值、花括号语法、单引号不插值 | `"$var"` `"{$var}"` |
+| 32 | expression: type_cast | 完整度->单应用追踪->表达式 | 1 | 1 | `(string)` 保留污点、`(int)` 语义丢失 | — |
+| 33 | expression: destructuring | 完整度->单应用追踪->表达式 | 2 | 2 | `list()` / `[$a,$b]` 数组解构 | `list()` |
+| 34 | expression: spread | 完整度->单应用追踪->表达式 | 2 | 2 | `...$args` 函数参数展开、数组解包 | `...` |
+| 35 | expression: nullsafe | 完整度->单应用追踪->表达式 | 2 | 2 | `?->` 运算符、链式 nullsafe | `?->` (PHP 8) |
+| 36 | expression: heredoc/nowdoc | 完整度->单应用追踪->表达式 | 2 | 2 | heredoc 插值传递污点、nowdoc 不插值 | `<<<EOT` |
+| 37 | expression: string_func | 完整度->单应用追踪->表达式 | 2 | 2 | sprintf/implode/str_replace | — |
+| 38 | function_call: anonymous/closure | 完整度->单应用追踪->函数调用 | 2 | 2 | 匿名函数闭包、箭头函数 `fn()` | `fn()` (PHP 7.4) |
+| 39 | function_call: argument_passing | 完整度->单应用追踪->函数调用 | 3 | 3 | 值传递、引用传参 `&$param`、多层调用 | `&$param` |
+| 40 | function_call: return_value | 完整度->单应用追踪->函数调用 | 2 | 2 | 返回值传递、嵌套函数返回值链 | — |
+| 41 | function_call: chained_call | 完整度->单应用追踪->函数调用 | 2 | 2 | `$obj->a()->b()` 链式方法调用 | — |
+| 42 | function_call: higher_order | 完整度->单应用追踪->函数调用 | 2 | 2 | array_map/array_filter/usort | — |
+| 43 | function_call: static_method | 完整度->单应用追踪->函数调用 | 2 | 2 | `ClassName::method()` 静态方法 | — |
+| 44 | function_call: variable_function | 完整度->单应用追踪->函数调用 | 2 | 2 | `$func()` / `call_user_func` | `$func()` |
+| 45 | function_call: named_arg | 完整度->单应用追踪->函数调用 | 2 | 2 | `func(name: $val)` 命名参数 | PHP 8 |
+| 46 | function_call: first_class_callable | 完整度->单应用追踪->函数调用 | 2 | 2 | `strlen(...)` 语法获取函数引用 | PHP 8.1 |
+| 47 | function_call: generator | 完整度->单应用追踪->函数调用 | 2 | 2 | `yield` / `yield from` 生成器 | — |
+| 48 | class: simple_object | 完整度->单应用追踪->类与对象 | 2 | 2 | 对象属性存取 | — |
+| 49 | class: subclass | 完整度->单应用追踪->类与对象 | 2 | 2 | 子类继承/重写 | — |
+| 50 | class: interface_impl | 完整度->单应用追踪->类与对象 | 2 | 2 | 接口实现类 | — |
+| 51 | class: trait | 完整度->单应用追踪->类与对象 | 2 | 2 | trait 方法/属性传递 | `trait` |
+| 52 | class: magic_method | 完整度->单应用追踪->类与对象 | 3 | 3 | `__get`/`__set`/`__toString`/`__invoke`/`__call` | 魔术方法 |
+| 53 | class: abstract_class | 完整度->单应用追踪->类与对象 | 1 | 1 | 抽象类子类实现 | — |
+| 54 | class: anonymous_class | 完整度->单应用追踪->类与对象 | 1 | 1 | `new class {}` 匿名类 | — |
+| 55 | class: late_static_binding | 完整度->单应用追踪->类与对象 | 1 | 1 | `static::method()` 后期静态绑定 | `static::` |
+| 56 | class: enum | 完整度->单应用追踪->类与对象 | 1 | 1 | enum 方法传递污点 | PHP 8.1 |
+| 57 | class: readonly | 完整度->单应用追踪->类与对象 | 1 | 1 | readonly 属性 | PHP 8.2 |
+| 58 | variable_scope: global | 完整度->单应用追踪->变量作用域 | 2 | 2 | `global $var` / `$GLOBALS` | `global` |
+| 59 | variable_scope: static | 完整度->单应用追踪->变量作用域 | 1 | 1 | 静态变量跨调用保留 | `static $var` |
+| 60 | variable_scope: closure_use | 完整度->单应用追踪->变量作用域 | 2 | 2 | `use ($var)` / `use (&$var)` | `use` |
+
+### completeness/dynamic_tracing（完整度-动态追踪）— 12 case
+
+| # | 子维度 | 评价项 | T | F | 说明 | PHP 特有 |
+|---|--------|--------|---|---|------|----------|
+| 61 | eval | 完整度->动态追踪->eval | 2 | 2 | eval 拼接执行、eval 赋值后传 sink | `eval()` |
+| 62 | variable_variables | 完整度->动态追踪->可变变量 | 2 | 2 | `$$name` 间接引用、循环中可变变量 | `$$var` |
+| 63 | compact_extract | 完整度->动态追踪->compact与extract | 2 | 2 | `compact()` 打包 / `extract()` 解包 | `compact`/`extract` |
+
+## PHP 特有语法覆盖汇总
+
+| 语法特性 | 所在维度 | case 数 |
+|----------|----------|---------|
+| 引用赋值 `&$var` | alias, argument_passing | 8 |
+| 魔术方法 `__get/__set/__toString/__invoke/__call` | class/magic_method | 6 |
+| trait | class/trait, cross_file_trait | 8 |
+| 闭包 `use ($var)` / `use (&$var)` | variable_scope/closure_use | 4 |
+| 箭头函数 `fn()` | function_call/anonymous_function | 2 |
+| match 表达式 | control_flow/conditional_stmt | 2 |
+| 可变函数 `$func()` / `call_user_func` | function_call/variable_function | 4 |
+| null 合并 `??` | expression/conditional_expression | 2 |
+| nullsafe `?->` | expression/nullsafe | 4 |
+| 字符串插值 `"$var"` / `"{$var}"` | expression/string_interpolation | 4 |
+| heredoc / nowdoc | expression/heredoc | 4 |
+| 数组解构 `list()` / `[$a,$b]` | expression/destructuring | 4 |
+| spread `...$args` | expression/spread | 4 |
+| named arguments | function_call/named_arg | 4 |
+| first-class callable `fn(...)` | function_call/first_class_callable | 4 |
+| generator / yield / yield from | function_call/generator | 4 |
+| enum | class/enum | 2 |
+| readonly | class/readonly | 2 |
+| late static binding `static::` | class/late_static_binding | 2 |
+| 匿名类 `new class {}` | class/anonymous_class | 2 |
+| 超全局变量 `$_POST/$_COOKIE/$_REQUEST/$_SERVER/$_SESSION` | datatype/superglobal | 10 |
+| eval | dynamic_tracing/eval | 4 |
+| 可变变量 `$$var` | dynamic_tracing/variable_variables | 4 |
+| compact / extract | dynamic_tracing/compact_extract | 4 |
+| `global $var` / `$GLOBALS` | variable_scope/global_variable | 4 |
+| 静态变量 `static $var` | variable_scope/static_variable | 2 |
+| namespace / use / use as | cross_file/namespace_use | 4 |
+| include / require / require_once | cross_file/include_require, require_once | 8 |
+| spl_autoload_register | cross_file/autoload | 4 |
+
+## case 文件格式
+
+```php
+<?php
+// evaluation information start
+// real case = true|false
+// evaluation item = 准确度|完整度->...->...
+// scene introduction = 场景描述
+// level = 1|2|3
+// bind_url = accuracy|completeness/.../case_name
+// evaluation information end
+
+function case_name_001_T($__taint_src) {
+    // 污点传播逻辑
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+case_name_001_T($taint_src);
+```
+
+| 字段 | 说明 |
+|------|------|
+| real case | `true` = T 用例（存在真实污点链路），`false` = F 用例（不存在） |
+| evaluation item | 中文评价维度路径 |
+| scene introduction | 场景简述 |
+| level | 难度等级：1=基础, 2=中等, 3=高级 |
+| bind_url | 从 accuracy/completeness 开始的相对路径（不含 .php） |
+| sink | 统一 `shell_exec()` 命令注入类 |
+| source | 函数参数 `$__taint_src` 或超全局变量 `$_GET/$_POST` 等 |

--- a/sast-php/case/accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_001_T.php
+++ b/sast-php/case/accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_001_T.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->上下文敏感->参数/返回值传递
+// scene introduction = 参数值传递，污染数据直接作为参数传入函数后到达sink
+// level = 2
+// bind_url = accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_001_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function process($arg) {
+    __taint_sink($arg);
+}
+
+function argument_return_value_passing_001_T($__taint_src) {
+    process($__taint_src);
+}
+
+$taint_src = "taint_src_value";
+argument_return_value_passing_001_T($taint_src);

--- a/sast-php/case/accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_002_F.php
+++ b/sast-php/case/accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_002_F.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->上下文敏感->参数/返回值传递
+// scene introduction = 参数值传递，安全数据作为参数传入函数后到达sink
+// level = 2
+// bind_url = accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_002_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function process($arg) {
+    __taint_sink($arg);
+}
+
+function argument_return_value_passing_002_F($__taint_src) {
+    process("safe_value");
+}
+
+$taint_src = "taint_src_value";
+argument_return_value_passing_002_F($taint_src);

--- a/sast-php/case/accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_003_T.php
+++ b/sast-php/case/accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_003_T.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->上下文敏感->参数/返回值传递
+// scene introduction = 返回值传递，函数返回污染数据后到达sink
+// level = 2
+// bind_url = accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_003_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function getData($arg) {
+    return $arg;
+}
+
+function argument_return_value_passing_003_T($__taint_src) {
+    $result = getData($__taint_src);
+    __taint_sink($result);
+}
+
+$taint_src = "taint_src_value";
+argument_return_value_passing_003_T($taint_src);

--- a/sast-php/case/accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_004_F.php
+++ b/sast-php/case/accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_004_F.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->上下文敏感->参数/返回值传递
+// scene introduction = 返回值传递，函数返回安全数据后到达sink
+// level = 2
+// bind_url = accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_004_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function getData($arg) {
+    return "safe_value";
+}
+
+function argument_return_value_passing_004_F($__taint_src) {
+    $result = getData($__taint_src);
+    __taint_sink($result);
+}
+
+$taint_src = "taint_src_value";
+argument_return_value_passing_004_F($taint_src);

--- a/sast-php/case/accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_005_T.php
+++ b/sast-php/case/accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_005_T.php
@@ -1,0 +1,27 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->上下文敏感->参数/返回值传递
+// scene introduction = 多层参数传递，污染数据经过多层函数参数传递到达sink
+// level = 2
+// bind_url = accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_005_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function layer1($arg) {
+    layer2($arg);
+}
+
+function layer2($arg) {
+    __taint_sink($arg);
+}
+
+function argument_return_value_passing_005_T($__taint_src) {
+    layer1($__taint_src);
+}
+
+$taint_src = "taint_src_value";
+argument_return_value_passing_005_T($taint_src);

--- a/sast-php/case/accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_006_F.php
+++ b/sast-php/case/accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_006_F.php
@@ -1,0 +1,27 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->上下文敏感->参数/返回值传递
+// scene introduction = 多层参数传递，安全数据经过多层函数参数传递到达sink
+// level = 2
+// bind_url = accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_006_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function layer1($arg) {
+    layer2($arg);
+}
+
+function layer2($arg) {
+    __taint_sink($arg);
+}
+
+function argument_return_value_passing_006_F($__taint_src) {
+    layer1("safe_value");
+}
+
+$taint_src = "taint_src_value";
+argument_return_value_passing_006_F($taint_src);

--- a/sast-php/case/accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_007_T.php
+++ b/sast-php/case/accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_007_T.php
@@ -1,0 +1,28 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->上下文敏感->参数/返回值传递
+// scene introduction = 多层返回值传递，污染数据经过多层函数返回值传递到达sink
+// level = 2
+// bind_url = accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_007_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function inner($arg) {
+    return $arg;
+}
+
+function outer($arg) {
+    return inner($arg);
+}
+
+function argument_return_value_passing_007_T($__taint_src) {
+    $result = outer($__taint_src);
+    __taint_sink($result);
+}
+
+$taint_src = "taint_src_value";
+argument_return_value_passing_007_T($taint_src);

--- a/sast-php/case/accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_008_F.php
+++ b/sast-php/case/accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_008_F.php
@@ -1,0 +1,28 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->上下文敏感->参数/返回值传递
+// scene introduction = 多层返回值传递，函数链最终返回安全数据到达sink
+// level = 2
+// bind_url = accuracy/context_sensitive/argument_return_value_passing/argument_return_value_passing_008_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function inner($arg) {
+    return "safe_value";
+}
+
+function outer($arg) {
+    return inner($arg);
+}
+
+function argument_return_value_passing_008_F($__taint_src) {
+    $result = outer($__taint_src);
+    __taint_sink($result);
+}
+
+$taint_src = "taint_src_value";
+argument_return_value_passing_008_F($taint_src);

--- a/sast-php/case/accuracy/context_sensitive/multi_invoke/multi_invoke_001_T.php
+++ b/sast-php/case/accuracy/context_sensitive/multi_invoke/multi_invoke_001_T.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->上下文敏感->多次调用
+// scene introduction = 同一函数被多次调用，sink接收污染参数的返回值
+// level = 2
+// bind_url = accuracy/context_sensitive/multi_invoke/multi_invoke_001_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function process($arg) {
+    return $arg;
+}
+
+function multi_invoke_001_T($__taint_src) {
+    $a = process($__taint_src);
+    $b = process("safe");
+    __taint_sink($a);
+}
+
+$taint_src = "taint_src_value";
+multi_invoke_001_T($taint_src);

--- a/sast-php/case/accuracy/context_sensitive/multi_invoke/multi_invoke_002_F.php
+++ b/sast-php/case/accuracy/context_sensitive/multi_invoke/multi_invoke_002_F.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->上下文敏感->多次调用
+// scene introduction = 同一函数被多次调用，sink接收安全参数的返回值
+// level = 2
+// bind_url = accuracy/context_sensitive/multi_invoke/multi_invoke_002_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function process($arg) {
+    return $arg;
+}
+
+function multi_invoke_002_F($__taint_src) {
+    $a = process($__taint_src);
+    $b = process("safe");
+    __taint_sink($b);
+}
+
+$taint_src = "taint_src_value";
+multi_invoke_002_F($taint_src);

--- a/sast-php/case/accuracy/context_sensitive/multi_invoke/multi_invoke_003_T.php
+++ b/sast-php/case/accuracy/context_sensitive/multi_invoke/multi_invoke_003_T.php
@@ -1,0 +1,29 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->上下文敏感->多次调用
+// scene introduction = 链式调用，污染数据经过多层函数传递后到达sink
+// level = 2
+// bind_url = accuracy/context_sensitive/multi_invoke/multi_invoke_003_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function step1($arg) {
+    return step2($arg);
+}
+
+function step2($arg) {
+    return $arg;
+}
+
+function multi_invoke_003_T($__taint_src) {
+    $a = step1($__taint_src);
+    $b = step1("safe");
+    __taint_sink($a);
+}
+
+$taint_src = "taint_src_value";
+multi_invoke_003_T($taint_src);

--- a/sast-php/case/accuracy/context_sensitive/multi_invoke/multi_invoke_004_F.php
+++ b/sast-php/case/accuracy/context_sensitive/multi_invoke/multi_invoke_004_F.php
@@ -1,0 +1,29 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->上下文敏感->多次调用
+// scene introduction = 链式调用，sink接收的是安全数据经过多层函数传递的结果
+// level = 2
+// bind_url = accuracy/context_sensitive/multi_invoke/multi_invoke_004_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function step1($arg) {
+    return step2($arg);
+}
+
+function step2($arg) {
+    return $arg;
+}
+
+function multi_invoke_004_F($__taint_src) {
+    $a = step1($__taint_src);
+    $b = step1("safe");
+    __taint_sink($b);
+}
+
+$taint_src = "taint_src_value";
+multi_invoke_004_F($taint_src);

--- a/sast-php/case/accuracy/context_sensitive/polymorphism/polymorphism_001_T.php
+++ b/sast-php/case/accuracy/context_sensitive/polymorphism/polymorphism_001_T.php
@@ -1,0 +1,37 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->上下文敏感->多态
+// scene introduction = 抽象类多态，子类实现传递污点数据
+// level = 2
+// bind_url = accuracy/context_sensitive/polymorphism/polymorphism_001_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+abstract class BaseHandler {
+    abstract public function handle($data);
+}
+
+class TaintHandler extends BaseHandler {
+    public function handle($data) {
+        return $data;
+    }
+}
+
+class SafeHandler extends BaseHandler {
+    public function handle($data) {
+        return "safe";
+    }
+}
+
+function polymorphism_001_T($__taint_src) {
+    $handler = new TaintHandler();
+    $result = $handler->handle($__taint_src);
+    __taint_sink($result);
+}
+
+$taint_src = "taint_src_value";
+polymorphism_001_T($taint_src);

--- a/sast-php/case/accuracy/context_sensitive/polymorphism/polymorphism_002_F.php
+++ b/sast-php/case/accuracy/context_sensitive/polymorphism/polymorphism_002_F.php
@@ -1,0 +1,37 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->上下文敏感->多态
+// scene introduction = 抽象类多态，子类实现返回安全数据
+// level = 2
+// bind_url = accuracy/context_sensitive/polymorphism/polymorphism_002_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+abstract class BaseHandler {
+    abstract public function handle($data);
+}
+
+class TaintHandler extends BaseHandler {
+    public function handle($data) {
+        return $data;
+    }
+}
+
+class SafeHandler extends BaseHandler {
+    public function handle($data) {
+        return "safe";
+    }
+}
+
+function polymorphism_002_F($__taint_src) {
+    $handler = new SafeHandler();
+    $result = $handler->handle($__taint_src);
+    __taint_sink($result);
+}
+
+$taint_src = "taint_src_value";
+polymorphism_002_F($taint_src);

--- a/sast-php/case/accuracy/context_sensitive/polymorphism/polymorphism_003_T.php
+++ b/sast-php/case/accuracy/context_sensitive/polymorphism/polymorphism_003_T.php
@@ -1,0 +1,37 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->上下文敏感->多态
+// scene introduction = 接口多态，实现类传递污点数据
+// level = 2
+// bind_url = accuracy/context_sensitive/polymorphism/polymorphism_003_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+interface DataProcessor {
+    public function process($data);
+}
+
+class PassthroughProcessor implements DataProcessor {
+    public function process($data) {
+        return $data;
+    }
+}
+
+class SanitizeProcessor implements DataProcessor {
+    public function process($data) {
+        return "sanitized";
+    }
+}
+
+function polymorphism_003_T($__taint_src) {
+    $processor = new PassthroughProcessor();
+    $result = $processor->process($__taint_src);
+    __taint_sink($result);
+}
+
+$taint_src = "taint_src_value";
+polymorphism_003_T($taint_src);

--- a/sast-php/case/accuracy/context_sensitive/polymorphism/polymorphism_004_F.php
+++ b/sast-php/case/accuracy/context_sensitive/polymorphism/polymorphism_004_F.php
@@ -1,0 +1,37 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->上下文敏感->多态
+// scene introduction = 接口多态，实现类返回安全数据
+// level = 2
+// bind_url = accuracy/context_sensitive/polymorphism/polymorphism_004_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+interface DataProcessor {
+    public function process($data);
+}
+
+class PassthroughProcessor implements DataProcessor {
+    public function process($data) {
+        return $data;
+    }
+}
+
+class SanitizeProcessor implements DataProcessor {
+    public function process($data) {
+        return "sanitized";
+    }
+}
+
+function polymorphism_004_F($__taint_src) {
+    $processor = new SanitizeProcessor();
+    $result = $processor->process($__taint_src);
+    __taint_sink($result);
+}
+
+$taint_src = "taint_src_value";
+polymorphism_004_F($taint_src);

--- a/sast-php/case/accuracy/flow_sensitive/loop_stmt/loop_stmt_001_T.php
+++ b/sast-php/case/accuracy/flow_sensitive/loop_stmt/loop_stmt_001_T.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->流敏感->循环语句
+// scene introduction = for循环体内，污染数据赋值后在同一迭代内流入sink
+// level = 2
+// bind_url = accuracy/flow_sensitive/loop_stmt/loop_stmt_001_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function loop_stmt_001_T($__taint_src) {
+    $res = "";
+    for ($i = 0; $i < 1; $i++) {
+        $res = $__taint_src;
+        __taint_sink($res);
+    }
+}
+
+$taint_src = "taint_src_value";
+loop_stmt_001_T($taint_src);

--- a/sast-php/case/accuracy/flow_sensitive/loop_stmt/loop_stmt_002_F.php
+++ b/sast-php/case/accuracy/flow_sensitive/loop_stmt/loop_stmt_002_F.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->流敏感->循环语句
+// scene introduction = for循环体内，sink在污染赋值之前执行，接收安全数据
+// level = 2
+// bind_url = accuracy/flow_sensitive/loop_stmt/loop_stmt_002_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function loop_stmt_002_F($__taint_src) {
+    $res = "safe";
+    for ($i = 0; $i < 1; $i++) {
+        __taint_sink($res);
+        $res = $__taint_src;
+    }
+}
+
+$taint_src = "taint_src_value";
+loop_stmt_002_F($taint_src);

--- a/sast-php/case/accuracy/flow_sensitive/loop_stmt/loop_stmt_003_T.php
+++ b/sast-php/case/accuracy/flow_sensitive/loop_stmt/loop_stmt_003_T.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->流敏感->循环语句
+// scene introduction = while循环体内，污染数据赋值后流入sink
+// level = 2
+// bind_url = accuracy/flow_sensitive/loop_stmt/loop_stmt_003_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function loop_stmt_003_T($__taint_src) {
+    $res = "";
+    $i = 0;
+    while ($i < 1) {
+        $res = $__taint_src;
+        __taint_sink($res);
+        $i++;
+    }
+}
+
+$taint_src = "taint_src_value";
+loop_stmt_003_T($taint_src);

--- a/sast-php/case/accuracy/flow_sensitive/loop_stmt/loop_stmt_004_F.php
+++ b/sast-php/case/accuracy/flow_sensitive/loop_stmt/loop_stmt_004_F.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->流敏感->循环语句
+// scene introduction = foreach循环体内，sink在污染赋值之前执行
+// level = 2
+// bind_url = accuracy/flow_sensitive/loop_stmt/loop_stmt_004_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function loop_stmt_004_F($__taint_src) {
+    $res = "safe";
+    $arr = [1];
+    foreach ($arr as $item) {
+        __taint_sink($res);
+        $res = $__taint_src;
+    }
+}
+
+$taint_src = "taint_src_value";
+loop_stmt_004_F($taint_src);

--- a/sast-php/case/accuracy/flow_sensitive/normal_stmt/normal_stmt_001_T.php
+++ b/sast-php/case/accuracy/flow_sensitive/normal_stmt/normal_stmt_001_T.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->流敏感->普通语句
+// scene introduction = 赋值表达式，污染数据赋值后立即流入sink
+// level = 2
+// bind_url = accuracy/flow_sensitive/normal_stmt/normal_stmt_001_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function normal_stmt_001_T($__taint_src) {
+    $result = $__taint_src;
+    __taint_sink($result);
+    $result = "safe";
+}
+
+$taint_src = "taint_src_value";
+normal_stmt_001_T($taint_src);

--- a/sast-php/case/accuracy/flow_sensitive/normal_stmt/normal_stmt_002_F.php
+++ b/sast-php/case/accuracy/flow_sensitive/normal_stmt/normal_stmt_002_F.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->流敏感->普通语句
+// scene introduction = 赋值表达式，变量先被赋安全值后流入sink，之后才被污染
+// level = 2
+// bind_url = accuracy/flow_sensitive/normal_stmt/normal_stmt_002_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function normal_stmt_002_F($__taint_src) {
+    $result = "safe";
+    __taint_sink($result);
+    $result = $__taint_src;
+}
+
+$taint_src = "taint_src_value";
+normal_stmt_002_F($taint_src);

--- a/sast-php/case/accuracy/flow_sensitive/normal_stmt/normal_stmt_003_T.php
+++ b/sast-php/case/accuracy/flow_sensitive/normal_stmt/normal_stmt_003_T.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->流敏感->普通语句
+// scene introduction = 多变量赋值，污染数据通过中间变量传递到sink
+// level = 2
+// bind_url = accuracy/flow_sensitive/normal_stmt/normal_stmt_003_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function normal_stmt_003_T($__taint_src) {
+    $a = $__taint_src;
+    $b = $a;
+    $c = $b;
+    __taint_sink($c);
+}
+
+$taint_src = "taint_src_value";
+normal_stmt_003_T($taint_src);

--- a/sast-php/case/accuracy/flow_sensitive/normal_stmt/normal_stmt_004_F.php
+++ b/sast-php/case/accuracy/flow_sensitive/normal_stmt/normal_stmt_004_F.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->流敏感->普通语句
+// scene introduction = 多变量赋值，污染数据被覆盖后安全值流入sink
+// level = 2
+// bind_url = accuracy/flow_sensitive/normal_stmt/normal_stmt_004_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function normal_stmt_004_F($__taint_src) {
+    $a = $__taint_src;
+    $a = "safe";
+    $b = $a;
+    __taint_sink($b);
+}
+
+$taint_src = "taint_src_value";
+normal_stmt_004_F($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/class_field/class_field_001_T.php
+++ b/sast-php/case/accuracy/object_field_sensitive/class_field/class_field_001_T.php
@@ -1,0 +1,30 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->对象域敏感->类字段
+// scene introduction = 类字段赋值污染数据后，通过字段访问流入sink
+// level = 2
+// bind_url = accuracy/object_field_sensitive/class_field/class_field_001_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+class DataHolder001 {
+    public $data;
+    public $safe;
+
+    public function __construct($input) {
+        $this->data = $input;
+        $this->safe = "safe_value";
+    }
+}
+
+function class_field_001_T($__taint_src) {
+    $obj = new DataHolder001($__taint_src);
+    __taint_sink($obj->data);
+}
+
+$taint_src = "taint_src_value";
+class_field_001_T($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/class_field/class_field_002_F.php
+++ b/sast-php/case/accuracy/object_field_sensitive/class_field/class_field_002_F.php
@@ -1,0 +1,30 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->对象域敏感->类字段
+// scene introduction = 类的不同字段区分，sink接收安全字段
+// level = 2
+// bind_url = accuracy/object_field_sensitive/class_field/class_field_002_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+class DataHolder002 {
+    public $data;
+    public $safe;
+
+    public function __construct($input) {
+        $this->data = $input;
+        $this->safe = "safe_value";
+    }
+}
+
+function class_field_002_F($__taint_src) {
+    $obj = new DataHolder002($__taint_src);
+    __taint_sink($obj->safe);
+}
+
+$taint_src = "taint_src_value";
+class_field_002_F($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/class_field/class_field_003_T.php
+++ b/sast-php/case/accuracy/object_field_sensitive/class_field/class_field_003_T.php
@@ -1,0 +1,33 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->对象域敏感->类字段
+// scene introduction = 通过setter方法设置污染数据到类字段，再通过getter获取流入sink
+// level = 2
+// bind_url = accuracy/object_field_sensitive/class_field/class_field_003_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+class Container003 {
+    private $value;
+
+    public function setValue($v) {
+        $this->value = $v;
+    }
+
+    public function getValue() {
+        return $this->value;
+    }
+}
+
+function class_field_003_T($__taint_src) {
+    $obj = new Container003();
+    $obj->setValue($__taint_src);
+    __taint_sink($obj->getValue());
+}
+
+$taint_src = "taint_src_value";
+class_field_003_T($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/class_field/class_field_004_F.php
+++ b/sast-php/case/accuracy/object_field_sensitive/class_field/class_field_004_F.php
@@ -1,0 +1,33 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->对象域敏感->类字段
+// scene introduction = 通过setter设置安全数据到类字段，getter返回安全值
+// level = 2
+// bind_url = accuracy/object_field_sensitive/class_field/class_field_004_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+class Container004 {
+    private $value;
+
+    public function setValue($v) {
+        $this->value = $v;
+    }
+
+    public function getValue() {
+        return $this->value;
+    }
+}
+
+function class_field_004_F($__taint_src) {
+    $obj = new Container004();
+    $obj->setValue("safe_value");
+    __taint_sink($obj->getValue());
+}
+
+$taint_src = "taint_src_value";
+class_field_004_F($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/class_field/class_field_005_T.php
+++ b/sast-php/case/accuracy/object_field_sensitive/class_field/class_field_005_T.php
@@ -1,0 +1,36 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->对象域敏感->类字段
+// scene introduction = 嵌套类字段，内层类字段持有污染数据
+// level = 2
+// bind_url = accuracy/object_field_sensitive/class_field/class_field_005_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+class Inner005 {
+    public $data;
+
+    public function __construct($v) {
+        $this->data = $v;
+    }
+}
+
+class Outer005 {
+    public $inner;
+
+    public function __construct($v) {
+        $this->inner = new Inner005($v);
+    }
+}
+
+function class_field_005_T($__taint_src) {
+    $obj = new Outer005($__taint_src);
+    __taint_sink($obj->inner->data);
+}
+
+$taint_src = "taint_src_value";
+class_field_005_T($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/class_field/class_field_006_F.php
+++ b/sast-php/case/accuracy/object_field_sensitive/class_field/class_field_006_F.php
@@ -1,0 +1,38 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->对象域敏感->类字段
+// scene introduction = 嵌套类字段，内层类字段持有安全数据
+// level = 2
+// bind_url = accuracy/object_field_sensitive/class_field/class_field_006_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+class Inner006 {
+    public $data;
+    public $safe;
+
+    public function __construct($v) {
+        $this->data = $v;
+        $this->safe = "safe_value";
+    }
+}
+
+class Outer006 {
+    public $inner;
+
+    public function __construct($v) {
+        $this->inner = new Inner006($v);
+    }
+}
+
+function class_field_006_F($__taint_src) {
+    $obj = new Outer006($__taint_src);
+    __taint_sink($obj->inner->safe);
+}
+
+$taint_src = "taint_src_value";
+class_field_006_F($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/field_len/field_len_001_T.php
+++ b/sast-php/case/accuracy/object_field_sensitive/field_len/field_len_001_T.php
@@ -1,0 +1,46 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->对象域敏感->域长度
+// scene introduction = 三层嵌套对象字段访问，末端持有污染数据
+// level = 2
+// bind_url = accuracy/object_field_sensitive/field_len/field_len_001_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+class C001 {
+    public $data;
+    public $safe;
+
+    public function __construct($v) {
+        $this->data = $v;
+        $this->safe = "safe";
+    }
+}
+
+class B001 {
+    public $c;
+
+    public function __construct($v) {
+        $this->c = new C001($v);
+    }
+}
+
+class A001 {
+    public $b;
+
+    public function __construct($v) {
+        $this->b = new B001($v);
+    }
+}
+
+function field_len_001_T($__taint_src) {
+    $a = new A001($__taint_src);
+    __taint_sink($a->b->c->data);
+}
+
+$taint_src = "taint_src_value";
+field_len_001_T($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/field_len/field_len_002_F.php
+++ b/sast-php/case/accuracy/object_field_sensitive/field_len/field_len_002_F.php
@@ -1,0 +1,46 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->对象域敏感->域长度
+// scene introduction = 三层嵌套对象字段访问，末端的safe字段持有安全数据
+// level = 2
+// bind_url = accuracy/object_field_sensitive/field_len/field_len_002_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+class C002 {
+    public $data;
+    public $safe;
+
+    public function __construct($v) {
+        $this->data = $v;
+        $this->safe = "safe";
+    }
+}
+
+class B002 {
+    public $c;
+
+    public function __construct($v) {
+        $this->c = new C002($v);
+    }
+}
+
+class A002 {
+    public $b;
+
+    public function __construct($v) {
+        $this->b = new B002($v);
+    }
+}
+
+function field_len_002_F($__taint_src) {
+    $a = new A002($__taint_src);
+    __taint_sink($a->b->c->safe);
+}
+
+$taint_src = "taint_src_value";
+field_len_002_F($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/field_len/field_len_003_T.php
+++ b/sast-php/case/accuracy/object_field_sensitive/field_len/field_len_003_T.php
@@ -1,0 +1,52 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->对象域敏感->域长度
+// scene introduction = 四层嵌套对象字段访问，深层字段持有污染数据
+// level = 2
+// bind_url = accuracy/object_field_sensitive/field_len/field_len_003_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+class D003 {
+    public $data;
+
+    public function __construct($v) {
+        $this->data = $v;
+    }
+}
+
+class C003 {
+    public $d;
+
+    public function __construct($v) {
+        $this->d = new D003($v);
+    }
+}
+
+class B003 {
+    public $c;
+
+    public function __construct($v) {
+        $this->c = new C003($v);
+    }
+}
+
+class A003 {
+    public $b;
+
+    public function __construct($v) {
+        $this->b = new B003($v);
+    }
+}
+
+function field_len_003_T($__taint_src) {
+    $a = new A003($__taint_src);
+    __taint_sink($a->b->c->d->data);
+}
+
+$taint_src = "taint_src_value";
+field_len_003_T($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/field_len/field_len_004_F.php
+++ b/sast-php/case/accuracy/object_field_sensitive/field_len/field_len_004_F.php
@@ -1,0 +1,53 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->对象域敏感->域长度
+// scene introduction = 四层嵌套对象字段访问，中间层字段被替换为安全值
+// level = 2
+// bind_url = accuracy/object_field_sensitive/field_len/field_len_004_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+class D004 {
+    public $data;
+
+    public function __construct($v) {
+        $this->data = $v;
+    }
+}
+
+class C004 {
+    public $d;
+
+    public function __construct($v) {
+        $this->d = new D004($v);
+    }
+}
+
+class B004 {
+    public $c;
+
+    public function __construct($v) {
+        $this->c = new C004($v);
+    }
+}
+
+class A004 {
+    public $b;
+
+    public function __construct($v) {
+        $this->b = new B004($v);
+    }
+}
+
+function field_len_004_F($__taint_src) {
+    $a = new A004($__taint_src);
+    $a->b->c->d->data = "safe";
+    __taint_sink($a->b->c->d->data);
+}
+
+$taint_src = "taint_src_value";
+field_len_004_F($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/field_len/field_len_005_T.php
+++ b/sast-php/case/accuracy/object_field_sensitive/field_len/field_len_005_T.php
@@ -1,0 +1,38 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->对象域敏感->域长度
+// scene introduction = 两层嵌套对象字段访问，二层字段持有污染数据
+// level = 2
+// bind_url = accuracy/object_field_sensitive/field_len/field_len_005_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+class Inner005FL {
+    public $data;
+    public $safe;
+
+    public function __construct($v) {
+        $this->data = $v;
+        $this->safe = "safe";
+    }
+}
+
+class Outer005FL {
+    public $inner;
+
+    public function __construct($v) {
+        $this->inner = new Inner005FL($v);
+    }
+}
+
+function field_len_005_T($__taint_src) {
+    $obj = new Outer005FL($__taint_src);
+    __taint_sink($obj->inner->data);
+}
+
+$taint_src = "taint_src_value";
+field_len_005_T($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/field_len/field_len_006_F.php
+++ b/sast-php/case/accuracy/object_field_sensitive/field_len/field_len_006_F.php
@@ -1,0 +1,38 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->对象域敏感->域长度
+// scene introduction = 两层嵌套对象字段访问，sink接收二层的安全字段
+// level = 2
+// bind_url = accuracy/object_field_sensitive/field_len/field_len_006_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+class Inner006FL {
+    public $data;
+    public $safe;
+
+    public function __construct($v) {
+        $this->data = $v;
+        $this->safe = "safe";
+    }
+}
+
+class Outer006FL {
+    public $inner;
+
+    public function __construct($v) {
+        $this->inner = new Inner006FL($v);
+    }
+}
+
+function field_len_006_F($__taint_src) {
+    $obj = new Outer006FL($__taint_src);
+    __taint_sink($obj->inner->safe);
+}
+
+$taint_src = "taint_src_value";
+field_len_006_F($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/multidimensional_collection/multidimensional_collection_001_T.php
+++ b/sast-php/case/accuracy/object_field_sensitive/multidimensional_collection/multidimensional_collection_001_T.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->对象域敏感->多维集合
+// scene introduction = 二维数组，污染数据在[0][0]位置，sink访问该位置
+// level = 2
+// bind_url = accuracy/object_field_sensitive/multidimensional_collection/multidimensional_collection_001_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function multidimensional_collection_001_T($__taint_src) {
+    $arr = [[$__taint_src, "safe"], ["safe_a", "safe_b"]];
+    __taint_sink($arr[0][0]);
+}
+
+$taint_src = "taint_src_value";
+multidimensional_collection_001_T($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/multidimensional_collection/multidimensional_collection_002_F.php
+++ b/sast-php/case/accuracy/object_field_sensitive/multidimensional_collection/multidimensional_collection_002_F.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->对象域敏感->多维集合
+// scene introduction = 二维数组，污染数据在[0][0]位置，sink访问[1][0]（安全）
+// level = 2
+// bind_url = accuracy/object_field_sensitive/multidimensional_collection/multidimensional_collection_002_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function multidimensional_collection_002_F($__taint_src) {
+    $arr = [[$__taint_src, "safe"], ["safe_a", "safe_b"]];
+    __taint_sink($arr[1][0]);
+}
+
+$taint_src = "taint_src_value";
+multidimensional_collection_002_F($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/multidimensional_collection/multidimensional_collection_003_T.php
+++ b/sast-php/case/accuracy/object_field_sensitive/multidimensional_collection/multidimensional_collection_003_T.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->对象域敏感->多维集合
+// scene introduction = 嵌套关联数组，污染数据通过多层key访问流入sink
+// level = 2
+// bind_url = accuracy/object_field_sensitive/multidimensional_collection/multidimensional_collection_003_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function multidimensional_collection_003_T($__taint_src) {
+    $map = [
+        "level1" => [
+            "tainted" => $__taint_src,
+            "safe" => "safe_value"
+        ]
+    ];
+    __taint_sink($map["level1"]["tainted"]);
+}
+
+$taint_src = "taint_src_value";
+multidimensional_collection_003_T($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/multidimensional_collection/multidimensional_collection_004_F.php
+++ b/sast-php/case/accuracy/object_field_sensitive/multidimensional_collection/multidimensional_collection_004_F.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->对象域敏感->多维集合
+// scene introduction = 嵌套关联数组，sink访问安全的key
+// level = 2
+// bind_url = accuracy/object_field_sensitive/multidimensional_collection/multidimensional_collection_004_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function multidimensional_collection_004_F($__taint_src) {
+    $map = [
+        "level1" => [
+            "tainted" => $__taint_src,
+            "safe" => "safe_value"
+        ]
+    ];
+    __taint_sink($map["level1"]["safe"]);
+}
+
+$taint_src = "taint_src_value";
+multidimensional_collection_004_F($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/object_sensitive/object_sensitive_001_T.php
+++ b/sast-php/case/accuracy/object_field_sensitive/object_sensitive/object_sensitive_001_T.php
@@ -1,0 +1,29 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->对象域敏感->对象敏感
+// scene introduction = 两个同类对象，污染对象和安全对象区分，sink接收污染对象
+// level = 2
+// bind_url = accuracy/object_field_sensitive/object_sensitive/object_sensitive_001_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+class Item001 {
+    public $data;
+
+    public function __construct($v) {
+        $this->data = $v;
+    }
+}
+
+function object_sensitive_001_T($__taint_src) {
+    $tainted = new Item001($__taint_src);
+    $safe = new Item001("safe_value");
+    __taint_sink($tainted->data);
+}
+
+$taint_src = "taint_src_value";
+object_sensitive_001_T($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/object_sensitive/object_sensitive_002_F.php
+++ b/sast-php/case/accuracy/object_field_sensitive/object_sensitive/object_sensitive_002_F.php
@@ -1,0 +1,29 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->对象域敏感->对象敏感
+// scene introduction = 两个同类对象，污染对象和安全对象区分，sink接收安全对象
+// level = 2
+// bind_url = accuracy/object_field_sensitive/object_sensitive/object_sensitive_002_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+class Item002 {
+    public $data;
+
+    public function __construct($v) {
+        $this->data = $v;
+    }
+}
+
+function object_sensitive_002_F($__taint_src) {
+    $tainted = new Item002($__taint_src);
+    $safe = new Item002("safe_value");
+    __taint_sink($safe->data);
+}
+
+$taint_src = "taint_src_value";
+object_sensitive_002_F($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/object_sensitive/object_sensitive_003_T.php
+++ b/sast-php/case/accuracy/object_field_sensitive/object_sensitive/object_sensitive_003_T.php
@@ -1,0 +1,28 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->对象域敏感->对象敏感
+// scene introduction = 数组中存放不同对象，取出污染对象的字段流入sink
+// level = 2
+// bind_url = accuracy/object_field_sensitive/object_sensitive/object_sensitive_003_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+class Item003 {
+    public $data;
+
+    public function __construct($v) {
+        $this->data = $v;
+    }
+}
+
+function object_sensitive_003_T($__taint_src) {
+    $arr = [new Item003($__taint_src), new Item003("safe_value")];
+    __taint_sink($arr[0]->data);
+}
+
+$taint_src = "taint_src_value";
+object_sensitive_003_T($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/object_sensitive/object_sensitive_004_F.php
+++ b/sast-php/case/accuracy/object_field_sensitive/object_sensitive/object_sensitive_004_F.php
@@ -1,0 +1,28 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->对象域敏感->对象敏感
+// scene introduction = 数组中存放不同对象，取出安全对象的字段流入sink
+// level = 2
+// bind_url = accuracy/object_field_sensitive/object_sensitive/object_sensitive_004_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+class Item004 {
+    public $data;
+
+    public function __construct($v) {
+        $this->data = $v;
+    }
+}
+
+function object_sensitive_004_F($__taint_src) {
+    $arr = [new Item004($__taint_src), new Item004("safe_value")];
+    __taint_sink($arr[1]->data);
+}
+
+$taint_src = "taint_src_value";
+object_sensitive_004_F($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/one_collection/one_collection_001_T.php
+++ b/sast-php/case/accuracy/object_field_sensitive/one_collection/one_collection_001_T.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->对象域敏感->一维集合
+// scene introduction = 数组索引，污染数据在索引0位置，sink访问索引0
+// level = 2
+// bind_url = accuracy/object_field_sensitive/one_collection/one_collection_001_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function one_collection_001_T($__taint_src) {
+    $arr = [$__taint_src, "safe_b", "safe_c"];
+    __taint_sink($arr[0]);
+}
+
+$taint_src = "taint_src_value";
+one_collection_001_T($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/one_collection/one_collection_002_F.php
+++ b/sast-php/case/accuracy/object_field_sensitive/one_collection/one_collection_002_F.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->对象域敏感->一维集合
+// scene introduction = 数组索引，污染数据在索引0位置，sink访问索引1（安全）
+// level = 2
+// bind_url = accuracy/object_field_sensitive/one_collection/one_collection_002_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function one_collection_002_F($__taint_src) {
+    $arr = [$__taint_src, "safe_b", "safe_c"];
+    __taint_sink($arr[1]);
+}
+
+$taint_src = "taint_src_value";
+one_collection_002_F($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/one_collection/one_collection_003_T.php
+++ b/sast-php/case/accuracy/object_field_sensitive/one_collection/one_collection_003_T.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->对象域敏感->一维集合
+// scene introduction = 关联数组，污染数据通过key访问流入sink
+// level = 2
+// bind_url = accuracy/object_field_sensitive/one_collection/one_collection_003_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function one_collection_003_T($__taint_src) {
+    $map = ["tainted" => $__taint_src, "safe" => "safe_value"];
+    __taint_sink($map["tainted"]);
+}
+
+$taint_src = "taint_src_value";
+one_collection_003_T($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/one_collection/one_collection_004_F.php
+++ b/sast-php/case/accuracy/object_field_sensitive/one_collection/one_collection_004_F.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->对象域敏感->一维集合
+// scene introduction = 关联数组，sink访问安全的key
+// level = 2
+// bind_url = accuracy/object_field_sensitive/one_collection/one_collection_004_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function one_collection_004_F($__taint_src) {
+    $map = ["tainted" => $__taint_src, "safe" => "safe_value"];
+    __taint_sink($map["safe"]);
+}
+
+$taint_src = "taint_src_value";
+one_collection_004_F($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/one_collection/one_collection_005_T.php
+++ b/sast-php/case/accuracy/object_field_sensitive/one_collection/one_collection_005_T.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->对象域敏感->一维集合
+// scene introduction = 数组push后通过索引访问污染数据
+// level = 2
+// bind_url = accuracy/object_field_sensitive/one_collection/one_collection_005_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function one_collection_005_T($__taint_src) {
+    $arr = [];
+    $arr[] = $__taint_src;
+    $arr[] = "safe";
+    __taint_sink($arr[0]);
+}
+
+$taint_src = "taint_src_value";
+one_collection_005_T($taint_src);

--- a/sast-php/case/accuracy/object_field_sensitive/one_collection/one_collection_006_F.php
+++ b/sast-php/case/accuracy/object_field_sensitive/one_collection/one_collection_006_F.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->对象域敏感->一维集合
+// scene introduction = 数组push后通过索引访问安全数据
+// level = 2
+// bind_url = accuracy/object_field_sensitive/one_collection/one_collection_006_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function one_collection_006_F($__taint_src) {
+    $arr = [];
+    $arr[] = $__taint_src;
+    $arr[] = "safe";
+    __taint_sink($arr[1]);
+}
+
+$taint_src = "taint_src_value";
+one_collection_006_F($taint_src);

--- a/sast-php/case/accuracy/path_sensitive/exception_throw/exception_throw_001_T.php
+++ b/sast-php/case/accuracy/path_sensitive/exception_throw/exception_throw_001_T.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->路径敏感->异常抛出
+// scene introduction = try块中sink在异常抛出前执行，接收污染数据
+// level = 2
+// bind_url = accuracy/path_sensitive/exception_throw/exception_throw_001_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function exception_throw_001_T($__taint_src) {
+    try {
+        __taint_sink($__taint_src);
+        throw new Exception("error");
+    } catch (Exception $e) {
+    }
+}
+
+$taint_src = "taint_src_value";
+exception_throw_001_T($taint_src);

--- a/sast-php/case/accuracy/path_sensitive/exception_throw/exception_throw_002_F.php
+++ b/sast-php/case/accuracy/path_sensitive/exception_throw/exception_throw_002_F.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->路径敏感->异常抛出
+// scene introduction = 异常在sink之前抛出，sink不会执行
+// level = 2
+// bind_url = accuracy/path_sensitive/exception_throw/exception_throw_002_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function exception_throw_002_F($__taint_src) {
+    try {
+        throw new Exception("error");
+        __taint_sink($__taint_src);
+    } catch (Exception $e) {
+    }
+}
+
+$taint_src = "taint_src_value";
+exception_throw_002_F($taint_src);

--- a/sast-php/case/accuracy/path_sensitive/exception_throw/exception_throw_003_T.php
+++ b/sast-php/case/accuracy/path_sensitive/exception_throw/exception_throw_003_T.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->路径敏感->异常抛出
+// scene introduction = catch块中捕获异常后，污染数据流入sink
+// level = 2
+// bind_url = accuracy/path_sensitive/exception_throw/exception_throw_003_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function exception_throw_003_T($__taint_src) {
+    try {
+        throw new Exception($__taint_src);
+    } catch (Exception $e) {
+        __taint_sink($e->getMessage());
+    }
+}
+
+$taint_src = "taint_src_value";
+exception_throw_003_T($taint_src);

--- a/sast-php/case/accuracy/path_sensitive/exception_throw/exception_throw_004_F.php
+++ b/sast-php/case/accuracy/path_sensitive/exception_throw/exception_throw_004_F.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->路径敏感->异常抛出
+// scene introduction = catch块中sink接收的是安全的异常消息，非污染数据
+// level = 2
+// bind_url = accuracy/path_sensitive/exception_throw/exception_throw_004_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function exception_throw_004_F($__taint_src) {
+    try {
+        $a = $__taint_src;
+        throw new Exception("safe_error");
+    } catch (Exception $e) {
+        __taint_sink($e->getMessage());
+    }
+}
+
+$taint_src = "taint_src_value";
+exception_throw_004_F($taint_src);

--- a/sast-php/case/accuracy/path_sensitive/explicit_jump_control/explicit_jump_control_001_T.php
+++ b/sast-php/case/accuracy/path_sensitive/explicit_jump_control/explicit_jump_control_001_T.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->路径敏感->跳转语句
+// scene introduction = break跳出循环后，污染数据已赋值，流入sink
+// level = 2
+// bind_url = accuracy/path_sensitive/explicit_jump_control/explicit_jump_control_001_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function explicit_jump_control_001_T($__taint_src) {
+    $res = "";
+    for ($i = 0; $i < 10; $i++) {
+        $res = $__taint_src;
+        break;
+    }
+    __taint_sink($res);
+}
+
+$taint_src = "taint_src_value";
+explicit_jump_control_001_T($taint_src);

--- a/sast-php/case/accuracy/path_sensitive/explicit_jump_control/explicit_jump_control_002_F.php
+++ b/sast-php/case/accuracy/path_sensitive/explicit_jump_control/explicit_jump_control_002_F.php
@@ -1,0 +1,26 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->路径敏感->跳转语句
+// scene introduction = break在污染赋值之前跳出循环，sink接收的是安全数据
+// level = 2
+// bind_url = accuracy/path_sensitive/explicit_jump_control/explicit_jump_control_002_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function explicit_jump_control_002_F($__taint_src) {
+    $res = "";
+    for ($i = 0; $i < 10; $i++) {
+        if ($i === 0) {
+            break;
+        }
+        $res = $__taint_src;
+    }
+    __taint_sink($res);
+}
+
+$taint_src = "taint_src_value";
+explicit_jump_control_002_F($taint_src);

--- a/sast-php/case/accuracy/path_sensitive/explicit_jump_control/explicit_jump_control_003_T.php
+++ b/sast-php/case/accuracy/path_sensitive/explicit_jump_control/explicit_jump_control_003_T.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->路径敏感->跳转语句
+// scene introduction = return提前返回污染数据
+// level = 2
+// bind_url = accuracy/path_sensitive/explicit_jump_control/explicit_jump_control_003_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function getResult($src) {
+    return $src;
+    return "safe";
+}
+
+function explicit_jump_control_003_T($__taint_src) {
+    $res = getResult($__taint_src);
+    __taint_sink($res);
+}
+
+$taint_src = "taint_src_value";
+explicit_jump_control_003_T($taint_src);

--- a/sast-php/case/accuracy/path_sensitive/explicit_jump_control/explicit_jump_control_004_F.php
+++ b/sast-php/case/accuracy/path_sensitive/explicit_jump_control/explicit_jump_control_004_F.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->路径敏感->跳转语句
+// scene introduction = continue跳过当前迭代，污染赋值在continue之后不会执行
+// level = 2
+// bind_url = accuracy/path_sensitive/explicit_jump_control/explicit_jump_control_004_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function explicit_jump_control_004_F($__taint_src) {
+    $res = "safe";
+    for ($i = 0; $i < 3; $i++) {
+        continue;
+        $res = $__taint_src;
+    }
+    __taint_sink($res);
+}
+
+$taint_src = "taint_src_value";
+explicit_jump_control_004_F($taint_src);

--- a/sast-php/case/accuracy/path_sensitive/loop_conditional_stmt/loop_conditional_stmt_001_T.php
+++ b/sast-php/case/accuracy/path_sensitive/loop_conditional_stmt/loop_conditional_stmt_001_T.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->路径敏感->条件循环语句
+// scene introduction = if条件为true时，污染数据流入sink
+// level = 2
+// bind_url = accuracy/path_sensitive/loop_conditional_stmt/loop_conditional_stmt_001_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function loop_conditional_stmt_001_T($__taint_src) {
+    $res = "safe";
+    if (true) {
+        $res = $__taint_src;
+    }
+    __taint_sink($res);
+}
+
+$taint_src = "taint_src_value";
+loop_conditional_stmt_001_T($taint_src);

--- a/sast-php/case/accuracy/path_sensitive/loop_conditional_stmt/loop_conditional_stmt_002_F.php
+++ b/sast-php/case/accuracy/path_sensitive/loop_conditional_stmt/loop_conditional_stmt_002_F.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->路径敏感->条件循环语句
+// scene introduction = if条件为false时，污染数据不会流入sink
+// level = 2
+// bind_url = accuracy/path_sensitive/loop_conditional_stmt/loop_conditional_stmt_002_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function loop_conditional_stmt_002_F($__taint_src) {
+    $res = "safe";
+    if (false) {
+        $res = $__taint_src;
+    }
+    __taint_sink($res);
+}
+
+$taint_src = "taint_src_value";
+loop_conditional_stmt_002_F($taint_src);

--- a/sast-php/case/accuracy/path_sensitive/loop_conditional_stmt/loop_conditional_stmt_003_T.php
+++ b/sast-php/case/accuracy/path_sensitive/loop_conditional_stmt/loop_conditional_stmt_003_T.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->路径敏感->条件循环语句
+// scene introduction = while循环中污染数据在循环体内流入sink
+// level = 2
+// bind_url = accuracy/path_sensitive/loop_conditional_stmt/loop_conditional_stmt_003_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function loop_conditional_stmt_003_T($__taint_src) {
+    $res = "safe";
+    $i = 0;
+    while ($i < 1) {
+        $res = $__taint_src;
+        $i++;
+    }
+    __taint_sink($res);
+}
+
+$taint_src = "taint_src_value";
+loop_conditional_stmt_003_T($taint_src);

--- a/sast-php/case/accuracy/path_sensitive/loop_conditional_stmt/loop_conditional_stmt_004_F.php
+++ b/sast-php/case/accuracy/path_sensitive/loop_conditional_stmt/loop_conditional_stmt_004_F.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->路径敏感->条件循环语句
+// scene introduction = while循环条件不满足，污染数据不会在循环体内赋值
+// level = 2
+// bind_url = accuracy/path_sensitive/loop_conditional_stmt/loop_conditional_stmt_004_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function loop_conditional_stmt_004_F($__taint_src) {
+    $res = "safe";
+    $i = 0;
+    while ($i < 0) {
+        $res = $__taint_src;
+        $i++;
+    }
+    __taint_sink($res);
+}
+
+$taint_src = "taint_src_value";
+loop_conditional_stmt_004_F($taint_src);

--- a/sast-php/case/accuracy/path_sensitive/loop_conditional_stmt/loop_conditional_stmt_005_T.php
+++ b/sast-php/case/accuracy/path_sensitive/loop_conditional_stmt/loop_conditional_stmt_005_T.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 准确度->路径敏感->条件循环语句
+// scene introduction = if-else分支中，else分支传递污染数据到sink
+// level = 2
+// bind_url = accuracy/path_sensitive/loop_conditional_stmt/loop_conditional_stmt_005_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function loop_conditional_stmt_005_T($__taint_src) {
+    $res = "safe";
+    if (false) {
+        $res = "still_safe";
+    } else {
+        $res = $__taint_src;
+    }
+    __taint_sink($res);
+}
+
+$taint_src = "taint_src_value";
+loop_conditional_stmt_005_T($taint_src);

--- a/sast-php/case/accuracy/path_sensitive/loop_conditional_stmt/loop_conditional_stmt_006_F.php
+++ b/sast-php/case/accuracy/path_sensitive/loop_conditional_stmt/loop_conditional_stmt_006_F.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 准确度->路径敏感->条件循环语句
+// scene introduction = if-else分支中，else分支传递安全数据到sink，污染数据在if分支
+// level = 2
+// bind_url = accuracy/path_sensitive/loop_conditional_stmt/loop_conditional_stmt_006_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function loop_conditional_stmt_006_F($__taint_src) {
+    $res = "safe";
+    if (true) {
+        $res = "still_safe";
+    } else {
+        $res = $__taint_src;
+    }
+    __taint_sink($res);
+}
+
+$taint_src = "taint_src_value";
+loop_conditional_stmt_006_F($taint_src);

--- a/sast-php/case/completeness/dynamic_tracing/compact_extract/compact_extract_001_F.php
+++ b/sast-php/case/completeness/dynamic_tracing/compact_extract/compact_extract_001_F.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->动态追踪->compact与extract
+// scene introduction = compact 打包的变量是安全的硬编码，污点未传递
+// level = 3
+// bind_url = completeness/dynamic_tracing/compact_extract/compact_extract_001_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function compact_extract_001_F($__taint_src) {
+    $cmd = 'safe_value';
+    $data = compact('cmd');
+    __taint_sink($data['cmd']);
+}
+
+$taint_src = "taint_src_value";
+compact_extract_001_F($taint_src);

--- a/sast-php/case/completeness/dynamic_tracing/compact_extract/compact_extract_001_T.php
+++ b/sast-php/case/completeness/dynamic_tracing/compact_extract/compact_extract_001_T.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->动态追踪->compact与extract
+// scene introduction = compact() 将受污染变量打包为数组，后续从数组取值传入 sink
+// level = 3
+// bind_url = completeness/dynamic_tracing/compact_extract/compact_extract_001_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function compact_extract_001_T($__taint_src) {
+    $cmd = $__taint_src;
+    $data = compact('cmd');
+    __taint_sink($data['cmd']);
+}
+
+$taint_src = "taint_src_value";
+compact_extract_001_T($taint_src);

--- a/sast-php/case/completeness/dynamic_tracing/compact_extract/compact_extract_002_F.php
+++ b/sast-php/case/completeness/dynamic_tracing/compact_extract/compact_extract_002_F.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->动态追踪->compact与extract
+// scene introduction = extract 解包后使用的是数组中安全的键，污点未传入 sink
+// level = 3
+// bind_url = completeness/dynamic_tracing/compact_extract/compact_extract_002_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function compact_extract_002_F($__taint_src) {
+    $data = array('cmd' => $__taint_src, 'safe' => 'safe_value');
+    extract($data);
+    __taint_sink($safe);
+}
+
+$taint_src = "taint_src_value";
+compact_extract_002_F($taint_src);

--- a/sast-php/case/completeness/dynamic_tracing/compact_extract/compact_extract_002_T.php
+++ b/sast-php/case/completeness/dynamic_tracing/compact_extract/compact_extract_002_T.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->动态追踪->compact与extract
+// scene introduction = extract() 将含污染值的数组解包为变量，该变量传入 sink
+// level = 3
+// bind_url = completeness/dynamic_tracing/compact_extract/compact_extract_002_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function compact_extract_002_T($__taint_src) {
+    $data = array('cmd' => $__taint_src);
+    extract($data);
+    __taint_sink($cmd);
+}
+
+$taint_src = "taint_src_value";
+compact_extract_002_T($taint_src);

--- a/sast-php/case/completeness/dynamic_tracing/eval/eval_001_F.php
+++ b/sast-php/case/completeness/dynamic_tracing/eval/eval_001_F.php
@@ -1,0 +1,16 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->动态追踪->eval
+// scene introduction = eval 内只使用硬编码字符串，不涉及污染数据
+// level = 3
+// bind_url = completeness/dynamic_tracing/eval/eval_001_F
+// evaluation information end
+
+function eval_001_F($__taint_src) {
+    $safe = "echo 'hello'";
+    eval('shell_exec("ls -la");');
+}
+
+$taint_src = "taint_src_value";
+eval_001_F($taint_src);

--- a/sast-php/case/completeness/dynamic_tracing/eval/eval_001_T.php
+++ b/sast-php/case/completeness/dynamic_tracing/eval/eval_001_T.php
@@ -1,0 +1,16 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->动态追踪->eval
+// scene introduction = eval 执行拼接了污染数据的代码字符串，直接调用 shell_exec
+// level = 3
+// bind_url = completeness/dynamic_tracing/eval/eval_001_T
+// evaluation information end
+
+function eval_001_T($__taint_src) {
+    $code = 'shell_exec("' . $__taint_src . '");';
+    eval($code);
+}
+
+$taint_src = "taint_src_value";
+eval_001_T($taint_src);

--- a/sast-php/case/completeness/dynamic_tracing/eval/eval_002_F.php
+++ b/sast-php/case/completeness/dynamic_tracing/eval/eval_002_F.php
@@ -1,0 +1,17 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->动态追踪->eval
+// scene introduction = eval 拼接的是经过清洗的数据，污点被消除
+// level = 3
+// bind_url = completeness/dynamic_tracing/eval/eval_002_F
+// evaluation information end
+
+function eval_002_F($__taint_src) {
+    $sanitized = preg_replace('/[^a-zA-Z0-9]/', '', $__taint_src);
+    $code = 'shell_exec(' . escapeshellarg($sanitized) . ');';
+    eval($code);
+}
+
+$taint_src = "taint_src_value";
+eval_002_F($taint_src);

--- a/sast-php/case/completeness/dynamic_tracing/eval/eval_002_T.php
+++ b/sast-php/case/completeness/dynamic_tracing/eval/eval_002_T.php
@@ -1,0 +1,16 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->动态追踪->eval
+// scene introduction = eval 将污染数据赋值给变量，再将该变量传入 sink
+// level = 3
+// bind_url = completeness/dynamic_tracing/eval/eval_002_T
+// evaluation information end
+
+function eval_002_T($__taint_src) {
+    eval('$cmd = "' . $__taint_src . '";');
+    shell_exec($cmd);
+}
+
+$taint_src = "taint_src_value";
+eval_002_T($taint_src);

--- a/sast-php/case/completeness/dynamic_tracing/variable_variables/variable_variables_001_F.php
+++ b/sast-php/case/completeness/dynamic_tracing/variable_variables/variable_variables_001_F.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->动态追踪->可变变量
+// scene introduction = 可变变量赋值了安全值，污点未传递到 sink
+// level = 3
+// bind_url = completeness/dynamic_tracing/variable_variables/variable_variables_001_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function variable_variables_001_F($__taint_src) {
+    $name = 'cmd';
+    $$name = 'safe_value';
+    __taint_sink($cmd);
+}
+
+$taint_src = "taint_src_value";
+variable_variables_001_F($taint_src);

--- a/sast-php/case/completeness/dynamic_tracing/variable_variables/variable_variables_001_T.php
+++ b/sast-php/case/completeness/dynamic_tracing/variable_variables/variable_variables_001_T.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->动态追踪->可变变量
+// scene introduction = 通过可变变量 $$name 间接传递污点数据到 sink
+// level = 3
+// bind_url = completeness/dynamic_tracing/variable_variables/variable_variables_001_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function variable_variables_001_T($__taint_src) {
+    $name = 'cmd';
+    $$name = $__taint_src;
+    __taint_sink($cmd);
+}
+
+$taint_src = "taint_src_value";
+variable_variables_001_T($taint_src);

--- a/sast-php/case/completeness/dynamic_tracing/variable_variables/variable_variables_002_F.php
+++ b/sast-php/case/completeness/dynamic_tracing/variable_variables/variable_variables_002_F.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->动态追踪->可变变量
+// scene introduction = 可变变量名来自污染但值是安全的硬编码
+// level = 3
+// bind_url = completeness/dynamic_tracing/variable_variables/variable_variables_002_F
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function variable_variables_002_F($__taint_src) {
+    $varName = $__taint_src;
+    $$varName = 'safe_value';
+    $result = $$varName;
+    __taint_sink($result);
+}
+
+$taint_src = "taint_src_value";
+variable_variables_002_F($taint_src);

--- a/sast-php/case/completeness/dynamic_tracing/variable_variables/variable_variables_002_T.php
+++ b/sast-php/case/completeness/dynamic_tracing/variable_variables/variable_variables_002_T.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->动态追踪->可变变量
+// scene introduction = 循环中通过可变变量传递污点数据到 sink
+// level = 3
+// bind_url = completeness/dynamic_tracing/variable_variables/variable_variables_002_T
+// evaluation information end
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+function variable_variables_002_T($__taint_src) {
+    $vars = ['x', 'y', 'cmd'];
+    foreach ($vars as $v) {
+        $$v = $__taint_src;
+    }
+    __taint_sink($cmd);
+}
+
+$taint_src = "taint_src_value";
+variable_variables_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/alias/alias_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/alias/alias_001_F.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->别名
+// scene introduction = 普通变量赋值后覆盖，污点断开
+// level = 2
+// bind_url = completeness/single_app_tracing/alias/alias_001_F
+// evaluation information end
+
+function alias_001_F($__taint_src) {
+    $a = $__taint_src;
+    $b = $a;
+    $b = "safe_value";
+    __taint_sink($b);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+alias_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/alias/alias_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/alias/alias_001_T.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->别名
+// scene introduction = 普通变量赋值传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/alias/alias_001_T
+// evaluation information end
+
+function alias_001_T($__taint_src) {
+    $a = $__taint_src;
+    $b = $a;
+    __taint_sink($b);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+alias_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/alias/reference_assign_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/alias/reference_assign_001_F.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->别名
+// scene introduction = 引用赋值后 unset 引用，污点不再传递
+// level = 2
+// bind_url = completeness/single_app_tracing/alias/reference_assign_001_F
+// evaluation information end
+
+function reference_assign_001_F($__taint_src) {
+    $a = $__taint_src;
+    $b = &$a;
+    unset($b);
+    $b = "safe_value";
+    __taint_sink($b);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+reference_assign_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/alias/reference_assign_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/alias/reference_assign_001_T.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->别名
+// scene introduction = 引用赋值 &$var 传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/alias/reference_assign_001_T
+// evaluation information end
+
+function reference_assign_001_T($__taint_src) {
+    $a = $__taint_src;
+    $b = &$a;
+    __taint_sink($b);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+reference_assign_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/alias/reference_assign_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/alias/reference_assign_002_F.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->别名
+// scene introduction = 引用赋值后用安全值覆盖原变量
+// level = 2
+// bind_url = completeness/single_app_tracing/alias/reference_assign_002_F
+// evaluation information end
+
+function reference_assign_002_F($__taint_src) {
+    $a = $__taint_src;
+    $b = &$a;
+    $a = "safe_value";
+    __taint_sink($b);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+reference_assign_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/alias/reference_assign_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/alias/reference_assign_002_T.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->别名
+// scene introduction = 通过引用赋值修改原变量传播污点
+// level = 2
+// bind_url = completeness/single_app_tracing/alias/reference_assign_002_T
+// evaluation information end
+
+function reference_assign_002_T($__taint_src) {
+    $a = "safe";
+    $b = &$a;
+    $b = $__taint_src;
+    __taint_sink($a);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+reference_assign_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/abstract_class_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/class/abstract_class_001_F.php
@@ -1,0 +1,31 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 抽象类子类实现方法净化了数据
+// level = 2
+// bind_url = completeness/single_app_tracing/class/abstract_class_001_F
+// evaluation information end
+
+abstract class AbstractFilter {
+    abstract public function filter($data);
+}
+
+class SafeConcreteFilter extends AbstractFilter {
+    public function filter($data) {
+        return "safe_filtered";
+    }
+}
+
+function abstract_class_001_F($__taint_src) {
+    $filter = new SafeConcreteFilter();
+    $result = $filter->filter($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+abstract_class_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/abstract_class_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/class/abstract_class_001_T.php
@@ -1,0 +1,31 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 抽象类子类实现方法传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/class/abstract_class_001_T
+// evaluation information end
+
+abstract class AbstractHandler {
+    abstract public function handle($data);
+}
+
+class ConcreteHandler extends AbstractHandler {
+    public function handle($data) {
+        return $data;
+    }
+}
+
+function abstract_class_001_T($__taint_src) {
+    $handler = new ConcreteHandler();
+    $result = $handler->handle($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+abstract_class_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/anonymous_class_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/class/anonymous_class_001_F.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 匿名类方法返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/class/anonymous_class_001_F
+// evaluation information end
+
+function anonymous_class_001_F($__taint_src) {
+    $obj = new class {
+        public function run($data) {
+            return "safe_value";
+        }
+    };
+    $result = $obj->run($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+anonymous_class_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/anonymous_class_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/class/anonymous_class_001_T.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 匿名类方法传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/class/anonymous_class_001_T
+// evaluation information end
+
+function anonymous_class_001_T($__taint_src) {
+    $obj = new class {
+        public function run($data) {
+            return $data;
+        }
+    };
+    $result = $obj->run($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+anonymous_class_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/enum_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/class/enum_001_F.php
@@ -1,0 +1,30 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 枚举方法返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/class/enum_001_F
+// evaluation information end
+
+enum Color: string {
+    case Red = 'red';
+    case Blue = 'blue';
+
+    public function label($input): string {
+        return "safe_" . $this->value;
+    }
+}
+
+function enum_001_F($__taint_src) {
+    $color = Color::Red;
+    $result = $color->label($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+enum_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/enum_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/class/enum_001_T.php
@@ -1,0 +1,30 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 枚举方法传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/class/enum_001_T
+// evaluation information end
+
+enum Status: string {
+    case Active = 'active';
+    case Inactive = 'inactive';
+
+    public function format($input): string {
+        return $input;
+    }
+}
+
+function enum_001_T($__taint_src) {
+    $status = Status::Active;
+    $result = $status->format($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+enum_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/interface_impl_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/class/interface_impl_001_F.php
@@ -1,0 +1,31 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 接口实现类净化了数据
+// level = 2
+// bind_url = completeness/single_app_tracing/class/interface_impl_001_F
+// evaluation information end
+
+interface Filter {
+    public function filter($data);
+}
+
+class SafeFilter implements Filter {
+    public function filter($data) {
+        return "filtered_safe";
+    }
+}
+
+function interface_impl_001_F($__taint_src) {
+    $f = new SafeFilter();
+    $result = $f->filter($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+interface_impl_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/interface_impl_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/class/interface_impl_001_T.php
@@ -1,0 +1,31 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 接口实现类方法传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/class/interface_impl_001_T
+// evaluation information end
+
+interface DataProcessor {
+    public function process($data);
+}
+
+class TaintProcessor implements DataProcessor {
+    public function process($data) {
+        return $data;
+    }
+}
+
+function interface_impl_001_T($__taint_src) {
+    $processor = new TaintProcessor();
+    $result = $processor->process($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+interface_impl_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/interface_impl_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/class/interface_impl_002_F.php
@@ -1,0 +1,31 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 接口实现返回常量
+// level = 2
+// bind_url = completeness/single_app_tracing/class/interface_impl_002_F
+// evaluation information end
+
+interface Encoder {
+    public function encode($data);
+}
+
+class ConstEncoder implements Encoder {
+    public function encode($data) {
+        return "encoded_constant";
+    }
+}
+
+function interface_impl_002_F($__taint_src) {
+    $enc = new ConstEncoder();
+    $result = $enc->encode($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+interface_impl_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/interface_impl_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/class/interface_impl_002_T.php
@@ -1,0 +1,35 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 接口类型声明参数传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/class/interface_impl_002_T
+// evaluation information end
+
+interface Transformer {
+    public function transform($input);
+}
+
+class IdentityTransformer implements Transformer {
+    public function transform($input) {
+        return $input;
+    }
+}
+
+function processWithInterface(Transformer $t, $data) {
+    return $t->transform($data);
+}
+
+function interface_impl_002_T($__taint_src) {
+    $t = new IdentityTransformer();
+    $result = processWithInterface($t, $__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+interface_impl_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/late_static_binding_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/class/late_static_binding_001_F.php
@@ -1,0 +1,36 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 后期静态绑定子类返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/class/late_static_binding_001_F
+// evaluation information end
+
+class BaseProcessor {
+    public static function getData($input) {
+        return $input;
+    }
+
+    public static function process($input) {
+        return static::getData($input);
+    }
+}
+
+class SafeProcessor extends BaseProcessor {
+    public static function getData($input) {
+        return "safe_value";
+    }
+}
+
+function late_static_binding_001_F($__taint_src) {
+    $result = SafeProcessor::process($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+late_static_binding_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/late_static_binding_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/class/late_static_binding_001_T.php
@@ -1,0 +1,36 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 后期静态绑定子类重写返回污点
+// level = 2
+// bind_url = completeness/single_app_tracing/class/late_static_binding_001_T
+// evaluation information end
+
+class BaseProvider {
+    public static function getData($input) {
+        return "safe";
+    }
+
+    public static function process($input) {
+        return static::getData($input);
+    }
+}
+
+class TaintedProvider extends BaseProvider {
+    public static function getData($input) {
+        return $input;
+    }
+}
+
+function late_static_binding_001_T($__taint_src) {
+    $result = TaintedProvider::process($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+late_static_binding_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/magic_method_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/class/magic_method_001_F.php
@@ -1,0 +1,31 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = __get 魔术方法返回安全默认值
+// level = 2
+// bind_url = completeness/single_app_tracing/class/magic_method_001_F
+// evaluation information end
+
+class SafeMagicGet {
+    public function __set($name, $value) {
+        // 不存储
+    }
+
+    public function __get($name) {
+        return "safe_default";
+    }
+}
+
+function magic_method_001_F($__taint_src) {
+    $obj = new SafeMagicGet();
+    $obj->tainted = $__taint_src;
+    __taint_sink($obj->tainted);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+magic_method_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/magic_method_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/class/magic_method_001_T.php
@@ -1,0 +1,33 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = __get 魔术方法传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/class/magic_method_001_T
+// evaluation information end
+
+class MagicGet {
+    private $data = [];
+
+    public function __set($name, $value) {
+        $this->data[$name] = $value;
+    }
+
+    public function __get($name) {
+        return $this->data[$name] ?? null;
+    }
+}
+
+function magic_method_001_T($__taint_src) {
+    $obj = new MagicGet();
+    $obj->tainted = $__taint_src;
+    __taint_sink($obj->tainted);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+magic_method_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/magic_method_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/class/magic_method_002_F.php
@@ -1,0 +1,33 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = __toString 返回安全常量
+// level = 2
+// bind_url = completeness/single_app_tracing/class/magic_method_002_F
+// evaluation information end
+
+class SafeString {
+    private $value;
+
+    public function __construct($val) {
+        $this->value = $val;
+    }
+
+    public function __toString() {
+        return "safe_string_repr";
+    }
+}
+
+function magic_method_002_F($__taint_src) {
+    $obj = new SafeString($__taint_src);
+    $result = (string)$obj;
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+magic_method_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/magic_method_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/class/magic_method_002_T.php
@@ -1,0 +1,33 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = __toString 魔术方法传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/class/magic_method_002_T
+// evaluation information end
+
+class TaintString {
+    private $value;
+
+    public function __construct($val) {
+        $this->value = $val;
+    }
+
+    public function __toString() {
+        return $this->value;
+    }
+}
+
+function magic_method_002_T($__taint_src) {
+    $obj = new TaintString($__taint_src);
+    $result = (string)$obj;
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+magic_method_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/magic_method_003_F.php
+++ b/sast-php/case/completeness/single_app_tracing/class/magic_method_003_F.php
@@ -1,0 +1,27 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = __call 魔术方法返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/class/magic_method_003_F
+// evaluation information end
+
+class SafeCall {
+    public function __call($name, $args) {
+        return "safe_call_result";
+    }
+}
+
+function magic_method_003_F($__taint_src) {
+    $obj = new SafeCall();
+    $result = $obj->anyMethod($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+magic_method_003_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/magic_method_003_T.php
+++ b/sast-php/case/completeness/single_app_tracing/class/magic_method_003_T.php
@@ -1,0 +1,27 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = __invoke 魔术方法传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/class/magic_method_003_T
+// evaluation information end
+
+class InvokableClass {
+    public function __invoke($data) {
+        return $data;
+    }
+}
+
+function magic_method_003_T($__taint_src) {
+    $obj = new InvokableClass();
+    $result = $obj($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+magic_method_003_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/readonly_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/class/readonly_001_F.php
@@ -1,0 +1,28 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = readonly属性存入安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/class/readonly_001_F
+// evaluation information end
+
+class SafeConfig {
+    public readonly string $value;
+
+    public function __construct(string $input) {
+        $this->value = "safe_value";
+    }
+}
+
+function readonly_001_F($__taint_src) {
+    $config = new SafeConfig($__taint_src);
+    __taint_sink($config->value);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+readonly_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/readonly_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/class/readonly_001_T.php
@@ -1,0 +1,26 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = readonly属性构造时存入污点后读取
+// level = 2
+// bind_url = completeness/single_app_tracing/class/readonly_001_T
+// evaluation information end
+
+class Config {
+    public function __construct(
+        public readonly string $value
+    ) {}
+}
+
+function readonly_001_T($__taint_src) {
+    $config = new Config($__taint_src);
+    __taint_sink($config->value);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+readonly_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/simple_object_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/class/simple_object_001_F.php
@@ -1,0 +1,26 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 对象方法返回安全值
+// level = 1
+// bind_url = completeness/single_app_tracing/class/simple_object_001_F
+// evaluation information end
+
+class SafeHolder {
+    public function getSafe($val) {
+        return "safe_value";
+    }
+}
+
+function simple_object_001_F($__taint_src) {
+    $obj = new SafeHolder();
+    __taint_sink($obj->getSafe($__taint_src));
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+simple_object_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/simple_object_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/class/simple_object_001_T.php
@@ -1,0 +1,33 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 对象属性存取传递污点
+// level = 1
+// bind_url = completeness/single_app_tracing/class/simple_object_001_T
+// evaluation information end
+
+class DataHolder {
+    public $value;
+
+    public function setValue($val) {
+        $this->value = $val;
+    }
+
+    public function getValue() {
+        return $this->value;
+    }
+}
+
+function simple_object_001_T($__taint_src) {
+    $obj = new DataHolder();
+    $obj->setValue($__taint_src);
+    __taint_sink($obj->getValue());
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+simple_object_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/simple_object_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/class/simple_object_002_F.php
@@ -1,0 +1,26 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 对象属性被安全值覆盖后读取
+// level = 1
+// bind_url = completeness/single_app_tracing/class/simple_object_002_F
+// evaluation information end
+
+class Wrapper {
+    public $data;
+}
+
+function simple_object_002_F($__taint_src) {
+    $obj = new Wrapper();
+    $obj->data = $__taint_src;
+    $obj->data = "overwritten_safe";
+    __taint_sink($obj->data);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+simple_object_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/simple_object_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/class/simple_object_002_T.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 直接属性赋值传递污点
+// level = 1
+// bind_url = completeness/single_app_tracing/class/simple_object_002_T
+// evaluation information end
+
+class Container {
+    public $data;
+}
+
+function simple_object_002_T($__taint_src) {
+    $obj = new Container();
+    $obj->data = $__taint_src;
+    __taint_sink($obj->data);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+simple_object_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/subclass_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/class/subclass_001_F.php
@@ -1,0 +1,33 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 子类重写方法净化污点
+// level = 2
+// bind_url = completeness/single_app_tracing/class/subclass_001_F
+// evaluation information end
+
+class BaseHandler {
+    public function handle($data) {
+        return $data;
+    }
+}
+
+class SafeHandler extends BaseHandler {
+    public function handle($data) {
+        return "safe_handled";
+    }
+}
+
+function subclass_001_F($__taint_src) {
+    $obj = new SafeHandler();
+    $result = $obj->handle($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+subclass_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/subclass_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/class/subclass_001_T.php
@@ -1,0 +1,35 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 子类继承父类方法传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/class/subclass_001_T
+// evaluation information end
+
+class BaseClass {
+    protected $data;
+
+    public function setData($val) {
+        $this->data = $val;
+    }
+
+    public function getData() {
+        return $this->data;
+    }
+}
+
+class ChildClass extends BaseClass {}
+
+function subclass_001_T($__taint_src) {
+    $obj = new ChildClass();
+    $obj->setData($__taint_src);
+    __taint_sink($obj->getData());
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+subclass_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/subclass_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/class/subclass_002_F.php
@@ -1,0 +1,38 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 父类构造函数净化数据
+// level = 2
+// bind_url = completeness/single_app_tracing/class/subclass_002_F
+// evaluation information end
+
+class SafeBase {
+    protected $data;
+
+    public function __construct($val) {
+        $this->data = "safe_init";
+    }
+
+    public function getData() {
+        return $this->data;
+    }
+}
+
+class SafeChild extends SafeBase {
+    public function __construct($val) {
+        parent::__construct($val);
+    }
+}
+
+function subclass_002_F($__taint_src) {
+    $obj = new SafeChild($__taint_src);
+    __taint_sink($obj->getData());
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+subclass_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/subclass_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/class/subclass_002_T.php
@@ -1,0 +1,33 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 子类重写方法仍传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/class/subclass_002_T
+// evaluation information end
+
+class ParentProcessor {
+    public function process($data) {
+        return "parent_" . $data;
+    }
+}
+
+class ChildProcessor extends ParentProcessor {
+    public function process($data) {
+        return $data;
+    }
+}
+
+function subclass_002_T($__taint_src) {
+    $obj = new ChildProcessor();
+    $result = $obj->process($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+subclass_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/trait_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/class/trait_001_F.php
@@ -1,0 +1,31 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = trait 方法净化数据
+// level = 2
+// bind_url = completeness/single_app_tracing/class/trait_001_F
+// evaluation information end
+
+trait SanitizeTrait {
+    public function cleanData($data) {
+        return "trait_safe";
+    }
+}
+
+class TraitSanitizer {
+    use SanitizeTrait;
+}
+
+function trait_001_F($__taint_src) {
+    $obj = new TraitSanitizer();
+    $result = $obj->cleanData($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+trait_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/trait_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/class/trait_001_T.php
@@ -1,0 +1,31 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = trait 方法传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/class/trait_001_T
+// evaluation information end
+
+trait DataTrait {
+    public function passData($data) {
+        return $data;
+    }
+}
+
+class TraitUser {
+    use DataTrait;
+}
+
+function trait_001_T($__taint_src) {
+    $obj = new TraitUser();
+    $result = $obj->passData($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+trait_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/trait_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/class/trait_002_F.php
@@ -1,0 +1,35 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = 类方法覆盖 trait 方法返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/class/trait_002_F
+// evaluation information end
+
+trait PassTrait {
+    public function getData($data) {
+        return $data;
+    }
+}
+
+class OverrideTrait {
+    use PassTrait;
+
+    public function getData($data) {
+        return "overridden_safe";
+    }
+}
+
+function trait_002_F($__taint_src) {
+    $obj = new OverrideTrait();
+    $result = $obj->getData($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+trait_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/class/trait_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/class/trait_002_T.php
@@ -1,0 +1,37 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->类与对象
+// scene introduction = trait 属性存储和读取污点
+// level = 2
+// bind_url = completeness/single_app_tracing/class/trait_002_T
+// evaluation information end
+
+trait StorageTrait {
+    protected $stored;
+
+    public function store($val) {
+        $this->stored = $val;
+    }
+
+    public function retrieve() {
+        return $this->stored;
+    }
+}
+
+class StorageUser {
+    use StorageTrait;
+}
+
+function trait_002_T($__taint_src) {
+    $obj = new StorageUser();
+    $obj->store($__taint_src);
+    __taint_sink($obj->retrieve());
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+trait_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/control_flow/conditional_stmt/conditional_if_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/control_flow/conditional_stmt/conditional_if_001_T.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->控制流
+// scene introduction = if 分支中污点传递到 sink
+// level = 1
+// bind_url = completeness/single_app_tracing/control_flow/conditional_stmt/conditional_if_001_T
+// evaluation information end
+
+function conditional_if_001_T($__taint_src) {
+    $result = "safe";
+    if (strlen($__taint_src) > 0) {
+        $result = $__taint_src;
+    }
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+conditional_if_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/control_flow/conditional_stmt/conditional_if_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/control_flow/conditional_stmt/conditional_if_002_F.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->控制流
+// scene introduction = if 分支覆盖安全值，污点未到达 sink
+// level = 1
+// bind_url = completeness/single_app_tracing/control_flow/conditional_stmt/conditional_if_002_F
+// evaluation information end
+
+function conditional_if_002_F($__taint_src) {
+    $result = $__taint_src;
+    if (strlen($result) > 0) {
+        $result = "sanitized";
+    }
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+conditional_if_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/control_flow/conditional_stmt/conditional_match_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/control_flow/conditional_stmt/conditional_match_001_T.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->控制流
+// scene introduction = PHP 8 match 表达式传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/control_flow/conditional_stmt/conditional_match_001_T
+// evaluation information end
+
+function conditional_match_001_T($__taint_src) {
+    $type = 1;
+    $result = match($type) {
+        1 => $__taint_src,
+        2 => "safe_value",
+        default => "default_safe",
+    };
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+conditional_match_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/control_flow/conditional_stmt/conditional_match_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/control_flow/conditional_stmt/conditional_match_002_F.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->控制流
+// scene introduction = PHP 8 match 表达式所有分支均为安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/control_flow/conditional_stmt/conditional_match_002_F
+// evaluation information end
+
+function conditional_match_002_F($__taint_src) {
+    $type = 1;
+    $result = match($type) {
+        1 => "safe_a",
+        2 => "safe_b",
+        default => "safe_default",
+    };
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+conditional_match_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/control_flow/conditional_stmt/conditional_switch_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/control_flow/conditional_stmt/conditional_switch_001_T.php
@@ -1,0 +1,29 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->控制流
+// scene introduction = switch-case 分支中污点传递
+// level = 2
+// bind_url = completeness/single_app_tracing/control_flow/conditional_stmt/conditional_switch_001_T
+// evaluation information end
+
+function conditional_switch_001_T($__taint_src) {
+    $result = "";
+    $type = "exec";
+    switch ($type) {
+        case "exec":
+            $result = $__taint_src;
+            break;
+        case "safe":
+            $result = "safe_value";
+            break;
+    }
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+conditional_switch_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/control_flow/conditional_stmt/conditional_switch_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/control_flow/conditional_stmt/conditional_switch_002_F.php
@@ -1,0 +1,29 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->控制流
+// scene introduction = switch-case 所有分支都覆盖安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/control_flow/conditional_stmt/conditional_switch_002_F
+// evaluation information end
+
+function conditional_switch_002_F($__taint_src) {
+    $result = $__taint_src;
+    $type = "sanitize";
+    switch ($type) {
+        case "sanitize":
+            $result = "safe";
+            break;
+        default:
+            $result = "default_safe";
+            break;
+    }
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+conditional_switch_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/control_flow/loop_stmt/loop_for_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/control_flow/loop_stmt/loop_for_001_T.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->控制流
+// scene introduction = for 循环体内污点传递
+// level = 1
+// bind_url = completeness/single_app_tracing/control_flow/loop_stmt/loop_for_001_T
+// evaluation information end
+
+function loop_for_001_T($__taint_src) {
+    $result = "";
+    for ($i = 0; $i < 1; $i++) {
+        $result = $__taint_src;
+    }
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+loop_for_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/control_flow/loop_stmt/loop_for_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/control_flow/loop_stmt/loop_for_002_F.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->控制流
+// scene introduction = for 循环体内覆盖为安全值
+// level = 1
+// bind_url = completeness/single_app_tracing/control_flow/loop_stmt/loop_for_002_F
+// evaluation information end
+
+function loop_for_002_F($__taint_src) {
+    $result = $__taint_src;
+    for ($i = 0; $i < 1; $i++) {
+        $result = "safe_value";
+    }
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+loop_for_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/control_flow/loop_stmt/loop_foreach_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/control_flow/loop_stmt/loop_foreach_001_T.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->控制流
+// scene introduction = foreach 遍历数组传递污点
+// level = 1
+// bind_url = completeness/single_app_tracing/control_flow/loop_stmt/loop_foreach_001_T
+// evaluation information end
+
+function loop_foreach_001_T($__taint_src) {
+    $arr = [$__taint_src, "safe"];
+    $result = "";
+    foreach ($arr as $item) {
+        $result = $item;
+        break;
+    }
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+loop_foreach_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/control_flow/loop_stmt/loop_while_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/control_flow/loop_stmt/loop_while_002_F.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->控制流
+// scene introduction = while 循环中覆盖为安全值
+// level = 1
+// bind_url = completeness/single_app_tracing/control_flow/loop_stmt/loop_while_002_F
+// evaluation information end
+
+function loop_while_002_F($__taint_src) {
+    $result = $__taint_src;
+    $i = 0;
+    while ($i < 1) {
+        $result = "sanitized";
+        $i++;
+    }
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+loop_while_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/autoload_001_F/AutoClass.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/autoload_001_F/AutoClass.php
@@ -1,0 +1,13 @@
+<?php
+
+class AutoClass {
+    private $data;
+
+    public function __construct($input) {
+        $this->data = "safe_value";
+    }
+
+    public function getData() {
+        return $this->data;
+    }
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/autoload_001_F/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/autoload_001_F/main.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = spl_autoload_register 自动加载类，方法返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/autoload_001_F
+// evaluation information end
+
+spl_autoload_register(function ($class) {
+    require_once __DIR__ . '/' . $class . '.php';
+});
+
+function autoload_001_F($__taint_src) {
+    $obj = new AutoClass($__taint_src);
+    $result = $obj->getData();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+autoload_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/autoload_001_T/AutoClass.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/autoload_001_T/AutoClass.php
@@ -1,0 +1,13 @@
+<?php
+
+class AutoClass {
+    private $data;
+
+    public function __construct($input) {
+        $this->data = $input;
+    }
+
+    public function getData() {
+        return $this->data;
+    }
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/autoload_001_T/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/autoload_001_T/main.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = spl_autoload_register 自动加载类，实例化后方法传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/autoload_001_T
+// evaluation information end
+
+spl_autoload_register(function ($class) {
+    require_once __DIR__ . '/' . $class . '.php';
+});
+
+function autoload_001_T($__taint_src) {
+    $obj = new AutoClass($__taint_src);
+    $result = $obj->getData();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+autoload_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/autoload_002_F/Processor.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/autoload_002_F/Processor.php
@@ -1,0 +1,7 @@
+<?php
+
+class Processor {
+    public function handle($input) {
+        return "safe_value";
+    }
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/autoload_002_F/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/autoload_002_F/main.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = spl_autoload_register 自动加载不同类，方法返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/autoload_002_F
+// evaluation information end
+
+spl_autoload_register(function ($class) {
+    require_once __DIR__ . '/' . $class . '.php';
+});
+
+function autoload_002_F($__taint_src) {
+    $processor = new Processor();
+    $result = $processor->handle($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+autoload_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/autoload_002_T/Processor.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/autoload_002_T/Processor.php
@@ -1,0 +1,7 @@
+<?php
+
+class Processor {
+    public function handle($input) {
+        return $input;
+    }
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/autoload_002_T/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/autoload_002_T/main.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = spl_autoload_register 自动加载不同类，方法传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/autoload_002_T
+// evaluation information end
+
+spl_autoload_register(function ($class) {
+    require_once __DIR__ . '/' . $class . '.php';
+});
+
+function autoload_002_T($__taint_src) {
+    $processor = new Processor();
+    $result = $processor->handle($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+autoload_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_001_F/BaseHandler.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_001_F/BaseHandler.php
@@ -1,0 +1,7 @@
+<?php
+
+class BaseHandler {
+    public function handle($input) {
+        return "safe_value";
+    }
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_001_F/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_001_F/main.php
@@ -1,0 +1,26 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = 跨文件类继承，子类调用父类方法返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_001_F
+// evaluation information end
+
+require_once __DIR__ . '/BaseHandler.php';
+
+class ChildHandler extends BaseHandler {
+}
+
+function cross_file_inheritance_001_F($__taint_src) {
+    $handler = new ChildHandler();
+    $result = $handler->handle($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+cross_file_inheritance_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_001_T/BaseHandler.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_001_T/BaseHandler.php
@@ -1,0 +1,7 @@
+<?php
+
+class BaseHandler {
+    public function handle($input) {
+        return $input;
+    }
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_001_T/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_001_T/main.php
@@ -1,0 +1,26 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = 跨文件类继承，子类调用父类方法传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_001_T
+// evaluation information end
+
+require_once __DIR__ . '/BaseHandler.php';
+
+class ChildHandler extends BaseHandler {
+}
+
+function cross_file_inheritance_001_T($__taint_src) {
+    $handler = new ChildHandler();
+    $result = $handler->handle($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+cross_file_inheritance_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_002_F/AbstractProcessor.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_002_F/AbstractProcessor.php
@@ -1,0 +1,5 @@
+<?php
+
+abstract class AbstractProcessor {
+    abstract public function process($input);
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_002_F/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_002_F/main.php
@@ -1,0 +1,29 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = 跨文件抽象类继承，子类实现方法返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_002_F
+// evaluation information end
+
+require_once __DIR__ . '/AbstractProcessor.php';
+
+class ConcreteProcessor extends AbstractProcessor {
+    public function process($input) {
+        return "safe_value";
+    }
+}
+
+function cross_file_inheritance_002_F($__taint_src) {
+    $processor = new ConcreteProcessor();
+    $result = $processor->process($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+cross_file_inheritance_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_002_T/AbstractProcessor.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_002_T/AbstractProcessor.php
@@ -1,0 +1,5 @@
+<?php
+
+abstract class AbstractProcessor {
+    abstract public function process($input);
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_002_T/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_002_T/main.php
@@ -1,0 +1,29 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = 跨文件抽象类继承，子类实现方法传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/cross_file_inheritance_002_T
+// evaluation information end
+
+require_once __DIR__ . '/AbstractProcessor.php';
+
+class ConcreteProcessor extends AbstractProcessor {
+    public function process($input) {
+        return $input;
+    }
+}
+
+function cross_file_inheritance_002_T($__taint_src) {
+    $processor = new ConcreteProcessor();
+    $result = $processor->process($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+cross_file_inheritance_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_001_F/DataInterface.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_001_F/DataInterface.php
@@ -1,0 +1,5 @@
+<?php
+
+interface DataInterface {
+    public function transform($input);
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_001_F/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_001_F/main.php
@@ -1,0 +1,29 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = 跨文件 interface 实现类方法返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_001_F
+// evaluation information end
+
+require_once __DIR__ . '/DataInterface.php';
+
+class DataImpl implements DataInterface {
+    public function transform($input) {
+        return "safe_value";
+    }
+}
+
+function cross_file_interface_001_F($__taint_src) {
+    $obj = new DataImpl();
+    $result = $obj->transform($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+cross_file_interface_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_001_T/DataInterface.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_001_T/DataInterface.php
@@ -1,0 +1,5 @@
+<?php
+
+interface DataInterface {
+    public function transform($input);
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_001_T/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_001_T/main.php
@@ -1,0 +1,29 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = 跨文件 interface 实现类方法传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_001_T
+// evaluation information end
+
+require_once __DIR__ . '/DataInterface.php';
+
+class DataImpl implements DataInterface {
+    public function transform($input) {
+        return $input;
+    }
+}
+
+function cross_file_interface_001_T($__taint_src) {
+    $obj = new DataImpl();
+    $result = $obj->transform($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+cross_file_interface_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_002_F/Processable.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_002_F/Processable.php
@@ -1,0 +1,5 @@
+<?php
+
+interface Processable {
+    public function execute($input);
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_002_F/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_002_F/main.php
@@ -1,0 +1,29 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = 跨文件 Processable 接口实现类返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_002_F
+// evaluation information end
+
+require_once __DIR__ . '/Processable.php';
+
+class Worker implements Processable {
+    public function execute($input) {
+        return "safe_value";
+    }
+}
+
+function cross_file_interface_002_F($__taint_src) {
+    $worker = new Worker();
+    $result = $worker->execute($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+cross_file_interface_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_002_T/Processable.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_002_T/Processable.php
@@ -1,0 +1,5 @@
+<?php
+
+interface Processable {
+    public function execute($input);
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_002_T/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_002_T/main.php
@@ -1,0 +1,29 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = 跨文件 Processable 接口实现类传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/cross_file_interface_002_T
+// evaluation information end
+
+require_once __DIR__ . '/Processable.php';
+
+class Worker implements Processable {
+    public function execute($input) {
+        return $input;
+    }
+}
+
+function cross_file_interface_002_T($__taint_src) {
+    $worker = new Worker();
+    $result = $worker->execute($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+cross_file_interface_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_001_F/DataTrait.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_001_F/DataTrait.php
@@ -1,0 +1,7 @@
+<?php
+
+trait DataTrait {
+    public function process($input) {
+        return "safe_value";
+    }
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_001_F/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_001_F/main.php
@@ -1,0 +1,27 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = 跨文件 trait 方法返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_001_F
+// evaluation information end
+
+require_once __DIR__ . '/DataTrait.php';
+
+class DataHandler {
+    use DataTrait;
+}
+
+function cross_file_trait_001_F($__taint_src) {
+    $handler = new DataHandler();
+    $result = $handler->process($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+cross_file_trait_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_001_T/DataTrait.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_001_T/DataTrait.php
@@ -1,0 +1,7 @@
+<?php
+
+trait DataTrait {
+    public function process($input) {
+        return $input;
+    }
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_001_T/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_001_T/main.php
@@ -1,0 +1,27 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = 跨文件 trait 方法传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_001_T
+// evaluation information end
+
+require_once __DIR__ . '/DataTrait.php';
+
+class DataHandler {
+    use DataTrait;
+}
+
+function cross_file_trait_001_T($__taint_src) {
+    $handler = new DataHandler();
+    $result = $handler->process($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+cross_file_trait_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_002_F/HelperTrait.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_002_F/HelperTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+trait HelperTrait {
+    private $data;
+
+    public function setData($input) {
+        $this->data = "safe_value";
+    }
+
+    public function getData() {
+        return $this->data;
+    }
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_002_F/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_002_F/main.php
@@ -1,0 +1,28 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = 跨文件 trait 存储但返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_002_F
+// evaluation information end
+
+require_once __DIR__ . '/HelperTrait.php';
+
+class Service {
+    use HelperTrait;
+}
+
+function cross_file_trait_002_F($__taint_src) {
+    $svc = new Service();
+    $svc->setData($__taint_src);
+    $result = $svc->getData();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+cross_file_trait_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_002_T/HelperTrait.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_002_T/HelperTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+trait HelperTrait {
+    private $data;
+
+    public function setData($input) {
+        $this->data = $input;
+    }
+
+    public function getData() {
+        return $this->data;
+    }
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_002_T/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_002_T/main.php
@@ -1,0 +1,28 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = 跨文件 trait 存储并返回污点数据
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/cross_file_trait_002_T
+// evaluation information end
+
+require_once __DIR__ . '/HelperTrait.php';
+
+class Service {
+    use HelperTrait;
+}
+
+function cross_file_trait_002_T($__taint_src) {
+    $svc = new Service();
+    $svc->setData($__taint_src);
+    $result = $svc->getData();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+cross_file_trait_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/include_require_001_F/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/include_require_001_F/main.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = include 引入文件中函数净化了污点
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/include_require_001_F
+// evaluation information end
+
+include __DIR__ . '/sanitizer.php';
+
+function include_require_001_F($__taint_src) {
+    $result = sanitize($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+include_require_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/include_require_001_F/sanitizer.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/include_require_001_F/sanitizer.php
@@ -1,0 +1,5 @@
+<?php
+
+function sanitize($input) {
+    return "sanitized_value";
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/include_require_001_T/included_file.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/include_require_001_T/included_file.php
@@ -1,0 +1,5 @@
+<?php
+
+function pass_through($input) {
+    return $input;
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/include_require_001_T/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/include_require_001_T/main.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = include 引入文件中函数传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/include_require_001_T
+// evaluation information end
+
+include __DIR__ . '/included_file.php';
+
+function include_require_001_T($__taint_src) {
+    $result = pass_through($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+include_require_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/include_require_002_F/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/include_require_002_F/main.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = require 引入的类方法返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/include_require_002_F
+// evaluation information end
+
+require_once __DIR__ . '/safe_helper.php';
+
+function include_require_002_F($__taint_src) {
+    $helper = new SafeHelper();
+    $result = $helper->process($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+include_require_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/include_require_002_F/safe_helper.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/include_require_002_F/safe_helper.php
@@ -1,0 +1,7 @@
+<?php
+
+class SafeHelper {
+    public function process($data) {
+        return "safe_output";
+    }
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/include_require_002_T/helper.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/include_require_002_T/helper.php
@@ -1,0 +1,7 @@
+<?php
+
+class Helper {
+    public function process($data) {
+        return $data;
+    }
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/include_require_002_T/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/include_require_002_T/main.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = require_once 引入文件中类方法传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/include_require_002_T
+// evaluation information end
+
+require_once __DIR__ . '/helper.php';
+
+function include_require_002_T($__taint_src) {
+    $helper = new Helper();
+    $result = $helper->process($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+include_require_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/namespace_use_001_F/SafeClass.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/namespace_use_001_F/SafeClass.php
@@ -1,0 +1,8 @@
+<?php
+namespace App\Safe;
+
+class SafeClass {
+    public function clean($input) {
+        return "clean_value";
+    }
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/namespace_use_001_F/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/namespace_use_001_F/main.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = namespace 引入类方法净化了污点
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/namespace_use_001_F
+// evaluation information end
+
+require_once __DIR__ . '/SafeClass.php';
+
+use App\Safe\SafeClass;
+
+function namespace_use_001_F($__taint_src) {
+    $obj = new SafeClass();
+    $result = $obj->clean($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+namespace_use_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/namespace_use_001_T/MyClass.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/namespace_use_001_T/MyClass.php
@@ -1,0 +1,8 @@
+<?php
+namespace App\Utils;
+
+class MyClass {
+    public function getData($input) {
+        return $input;
+    }
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/namespace_use_001_T/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/namespace_use_001_T/main.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = namespace + use 引入类传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/namespace_use_001_T
+// evaluation information end
+
+require_once __DIR__ . '/MyClass.php';
+
+use App\Utils\MyClass;
+
+function namespace_use_001_T($__taint_src) {
+    $obj = new MyClass();
+    $result = $obj->getData($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+namespace_use_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/namespace_use_002_F/Sanitizer.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/namespace_use_002_F/Sanitizer.php
@@ -1,0 +1,8 @@
+<?php
+namespace App\Security;
+
+class Sanitizer {
+    public static function sanitize($data) {
+        return "safe_output";
+    }
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/namespace_use_002_F/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/namespace_use_002_F/main.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = namespace 静态方法返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/namespace_use_002_F
+// evaluation information end
+
+require_once __DIR__ . '/Sanitizer.php';
+
+use App\Security\Sanitizer as San;
+
+function namespace_use_002_F($__taint_src) {
+    $result = San::sanitize($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+namespace_use_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/namespace_use_002_T/Processor.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/namespace_use_002_T/Processor.php
@@ -1,0 +1,8 @@
+<?php
+namespace App\Services;
+
+class Processor {
+    public static function handle($data) {
+        return $data;
+    }
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/namespace_use_002_T/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/namespace_use_002_T/main.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = namespace 别名 use as 传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/namespace_use_002_T
+// evaluation information end
+
+require_once __DIR__ . '/Processor.php';
+
+use App\Services\Processor as Proc;
+
+function namespace_use_002_T($__taint_src) {
+    $result = Proc::handle($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+namespace_use_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/require_once_001_F/helper.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/require_once_001_F/helper.php
@@ -1,0 +1,5 @@
+<?php
+
+function sanitize($input) {
+    return "sanitized_value";
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/require_once_001_F/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/require_once_001_F/main.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = require_once 引入文件中函数净化了污点
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/require_once_001_F
+// evaluation information end
+
+require_once __DIR__ . '/helper.php';
+
+function require_once_001_F($__taint_src) {
+    $result = sanitize($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+require_once_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/require_once_001_T/helper.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/require_once_001_T/helper.php
@@ -1,0 +1,5 @@
+<?php
+
+function pass_through($input) {
+    return $input;
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/require_once_001_T/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/require_once_001_T/main.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = require_once 引入文件中函数传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/require_once_001_T
+// evaluation information end
+
+require_once __DIR__ . '/helper.php';
+
+function require_once_001_T($__taint_src) {
+    $result = pass_through($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+require_once_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/require_once_002_F/MyClass.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/require_once_002_F/MyClass.php
@@ -1,0 +1,7 @@
+<?php
+
+class MyClass {
+    public function process($input) {
+        return "safe_value";
+    }
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/require_once_002_F/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/require_once_002_F/main.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = require_once 引入类定义，方法返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/require_once_002_F
+// evaluation information end
+
+require_once __DIR__ . '/MyClass.php';
+
+function require_once_002_F($__taint_src) {
+    $obj = new MyClass();
+    $result = $obj->process($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+require_once_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/require_once_002_T/MyClass.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/require_once_002_T/MyClass.php
@@ -1,0 +1,7 @@
+<?php
+
+class MyClass {
+    public function process($input) {
+        return $input;
+    }
+}

--- a/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/require_once_002_T/main.php
+++ b/sast-php/case/completeness/single_app_tracing/cross_file_package_namespace/require_once_002_T/main.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->跨文件
+// scene introduction = require_once 引入类定义，实例化后方法传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/cross_file_package_namespace/require_once_002_T
+// evaluation information end
+
+require_once __DIR__ . '/MyClass.php';
+
+function require_once_002_T($__taint_src) {
+    $obj = new MyClass();
+    $result = $obj->process($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+require_once_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/datatype/array_element_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/array_element_001_T.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = 数组元素存储和读取污点
+// level = 1
+// bind_url = completeness/single_app_tracing/datatype/array_element_001_T
+// evaluation information end
+
+function array_element_001_T($__taint_src) {
+    $arr = [];
+    $arr['key'] = $__taint_src;
+    __taint_sink($arr['key']);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+array_element_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/datatype/array_overwrite_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/array_overwrite_001_F.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = 数组元素被安全值覆盖
+// level = 1
+// bind_url = completeness/single_app_tracing/datatype/array_overwrite_001_F
+// evaluation information end
+
+function array_overwrite_001_F($__taint_src) {
+    $arr = ['key' => $__taint_src];
+    $arr['key'] = "safe_value";
+    __taint_sink($arr['key']);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+array_overwrite_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/datatype/array_push_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/array_push_002_T.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = array_push 添加污点后 array_pop 取出
+// level = 2
+// bind_url = completeness/single_app_tracing/datatype/array_push_002_T
+// evaluation information end
+
+function array_push_002_T($__taint_src) {
+    $arr = [];
+    array_push($arr, $__taint_src);
+    $result = array_pop($arr);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+array_push_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/datatype/array_safe_key_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/array_safe_key_002_F.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = 读取数组中安全键而非污点键
+// level = 2
+// bind_url = completeness/single_app_tracing/datatype/array_safe_key_002_F
+// evaluation information end
+
+function array_safe_key_002_F($__taint_src) {
+    $arr = [
+        'tainted' => $__taint_src,
+        'safe' => "safe_value",
+    ];
+    __taint_sink($arr['safe']);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+array_safe_key_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/datatype/int_arithmetic_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/int_arithmetic_001_F.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = 纯整数运算结果无污点
+// level = 2
+// bind_url = completeness/single_app_tracing/datatype/int_arithmetic_001_F
+// evaluation information end
+
+function int_arithmetic_001_F($__taint_src) {
+    $a = 10;
+    $b = 20;
+    $result = strval($a + $b);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+int_arithmetic_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/datatype/int_to_string_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/int_to_string_001_T.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = 整数转字符串拼接保留污点
+// level = 2
+// bind_url = completeness/single_app_tracing/datatype/int_to_string_001_T
+// evaluation information end
+
+function int_to_string_001_T($__taint_src) {
+    $num = 42;
+    $result = $__taint_src . strval($num);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+int_to_string_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/datatype/string_concat_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/string_concat_001_T.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = 字符串拼接传递污点
+// level = 1
+// bind_url = completeness/single_app_tracing/datatype/string_concat_001_T
+// evaluation information end
+
+function string_concat_001_T($__taint_src) {
+    $result = "prefix_" . $__taint_src;
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+string_concat_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/datatype/string_constant_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/string_constant_002_F.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = 字符串赋值为常量，污点断开
+// level = 1
+// bind_url = completeness/single_app_tracing/datatype/string_constant_002_F
+// evaluation information end
+
+function string_constant_002_F($__taint_src) {
+    $a = $__taint_src;
+    $a = "constant_safe_value";
+    __taint_sink($a);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+string_constant_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/datatype/string_replace_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/string_replace_001_F.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = str_replace 将污点完全替换为安全值
+// level = 1
+// bind_url = completeness/single_app_tracing/datatype/string_replace_001_F
+// evaluation information end
+
+function string_replace_001_F($__taint_src) {
+    $result = str_replace($__taint_src, "safe", $__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+string_replace_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/datatype/string_substr_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/string_substr_002_T.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = substr 截取字符串保留污点
+// level = 2
+// bind_url = completeness/single_app_tracing/datatype/string_substr_002_T
+// evaluation information end
+
+function string_substr_002_T($__taint_src) {
+    $result = substr($__taint_src, 0, 10);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+string_substr_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/datatype/superglobal_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/superglobal_001_F.php
@@ -1,0 +1,19 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = $_POST值经过htmlspecialchars清洗
+// level = 2
+// bind_url = completeness/single_app_tracing/datatype/superglobal_001_F
+// evaluation information end
+
+function superglobal_001_F() {
+    $input = htmlspecialchars($_POST['input'], ENT_QUOTES, 'UTF-8');
+    __taint_sink($input);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+superglobal_001_F();

--- a/sast-php/case/completeness/single_app_tracing/datatype/superglobal_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/superglobal_001_T.php
@@ -1,0 +1,19 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = $_POST超全局变量作为污点源
+// level = 2
+// bind_url = completeness/single_app_tracing/datatype/superglobal_001_T
+// evaluation information end
+
+function superglobal_001_T() {
+    $input = $_POST['input'];
+    __taint_sink($input);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+superglobal_001_T();

--- a/sast-php/case/completeness/single_app_tracing/datatype/superglobal_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/superglobal_002_F.php
@@ -1,0 +1,19 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = $_SERVER安全字段REQUEST_METHOD
+// level = 2
+// bind_url = completeness/single_app_tracing/datatype/superglobal_002_F
+// evaluation information end
+
+function superglobal_002_F() {
+    $method = $_SERVER['REQUEST_METHOD'];
+    __taint_sink($method);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+superglobal_002_F();

--- a/sast-php/case/completeness/single_app_tracing/datatype/superglobal_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/superglobal_002_T.php
@@ -1,0 +1,19 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = $_COOKIE超全局变量作为污点源
+// level = 2
+// bind_url = completeness/single_app_tracing/datatype/superglobal_002_T
+// evaluation information end
+
+function superglobal_002_T() {
+    $cookie = $_COOKIE['key'];
+    __taint_sink($cookie);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+superglobal_002_T();

--- a/sast-php/case/completeness/single_app_tracing/datatype/superglobal_003_F.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/superglobal_003_F.php
@@ -1,0 +1,19 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = $_REQUEST值经过intval转换为安全整数
+// level = 2
+// bind_url = completeness/single_app_tracing/datatype/superglobal_003_F
+// evaluation information end
+
+function superglobal_003_F() {
+    $data = intval($_REQUEST['data']);
+    __taint_sink($data);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+superglobal_003_F();

--- a/sast-php/case/completeness/single_app_tracing/datatype/superglobal_003_T.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/superglobal_003_T.php
@@ -1,0 +1,19 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = $_REQUEST超全局变量作为污点源
+// level = 2
+// bind_url = completeness/single_app_tracing/datatype/superglobal_003_T
+// evaluation information end
+
+function superglobal_003_T() {
+    $data = $_REQUEST['data'];
+    __taint_sink($data);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+superglobal_003_T();

--- a/sast-php/case/completeness/single_app_tracing/datatype/superglobal_004_F.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/superglobal_004_F.php
@@ -1,0 +1,19 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = $_SERVER HTTP头部经过过滤
+// level = 2
+// bind_url = completeness/single_app_tracing/datatype/superglobal_004_F
+// evaluation information end
+
+function superglobal_004_F() {
+    $ua = htmlspecialchars($_SERVER['HTTP_USER_AGENT'], ENT_QUOTES, 'UTF-8');
+    __taint_sink($ua);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+superglobal_004_F();

--- a/sast-php/case/completeness/single_app_tracing/datatype/superglobal_004_T.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/superglobal_004_T.php
@@ -1,0 +1,19 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = $_SERVER HTTP头部作为污点源
+// level = 2
+// bind_url = completeness/single_app_tracing/datatype/superglobal_004_T
+// evaluation information end
+
+function superglobal_004_T() {
+    $ua = $_SERVER['HTTP_USER_AGENT'];
+    __taint_sink($ua);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+superglobal_004_T();

--- a/sast-php/case/completeness/single_app_tracing/datatype/superglobal_005_F.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/superglobal_005_F.php
@@ -1,0 +1,19 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = $_SESSION值经过escapeshellarg清洗
+// level = 2
+// bind_url = completeness/single_app_tracing/datatype/superglobal_005_F
+// evaluation information end
+
+function superglobal_005_F() {
+    $data = escapeshellarg($_SESSION['key']);
+    __taint_sink($data);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+superglobal_005_F();

--- a/sast-php/case/completeness/single_app_tracing/datatype/superglobal_005_T.php
+++ b/sast-php/case/completeness/single_app_tracing/datatype/superglobal_005_T.php
@@ -1,0 +1,19 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->数据类型
+// scene introduction = $_SESSION超全局变量作为污点源
+// level = 2
+// bind_url = completeness/single_app_tracing/datatype/superglobal_005_T
+// evaluation information end
+
+function superglobal_005_T() {
+    $data = $_SESSION['key'];
+    __taint_sink($data);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+superglobal_005_T();

--- a/sast-php/case/completeness/single_app_tracing/exception_error/try_catch_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/exception_error/try_catch_001_F.php
@@ -1,0 +1,26 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->异常处理
+// scene introduction = catch 块中覆盖为安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/exception_error/try_catch_001_F
+// evaluation information end
+
+function try_catch_001_F($__taint_src) {
+    $result = "";
+    try {
+        $result = $__taint_src;
+        throw new Exception("error");
+    } catch (Exception $e) {
+        $result = "sanitized";
+    }
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+try_catch_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/exception_error/try_catch_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/exception_error/try_catch_001_T.php
@@ -1,0 +1,26 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->异常处理
+// scene introduction = try 块内污点传递到 catch 后仍到达 sink
+// level = 2
+// bind_url = completeness/single_app_tracing/exception_error/try_catch_001_T
+// evaluation information end
+
+function try_catch_001_T($__taint_src) {
+    $result = "";
+    try {
+        $result = $__taint_src;
+        throw new Exception("error");
+    } catch (Exception $e) {
+        // $result 仍为污点
+    }
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+try_catch_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/exception_error/try_catch_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/exception_error/try_catch_002_T.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->异常处理
+// scene introduction = catch 块中异常消息携带污点
+// level = 2
+// bind_url = completeness/single_app_tracing/exception_error/try_catch_002_T
+// evaluation information end
+
+function try_catch_002_T($__taint_src) {
+    try {
+        throw new Exception($__taint_src);
+    } catch (Exception $e) {
+        __taint_sink($e->getMessage());
+    }
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+try_catch_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/exception_error/try_finally_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/exception_error/try_finally_002_F.php
@@ -1,0 +1,27 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->异常处理
+// scene introduction = finally 块中覆盖为安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/exception_error/try_finally_002_F
+// evaluation information end
+
+function try_finally_002_F($__taint_src) {
+    $result = $__taint_src;
+    try {
+        throw new Exception("error");
+    } catch (Exception $e) {
+        // 不处理
+    } finally {
+        $result = "safe_value";
+    }
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+try_finally_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/basic_expression_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/basic_expression_001_F.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = 赋值表达式覆盖为安全值
+// level = 1
+// bind_url = completeness/single_app_tracing/expression/basic_expression_001_F
+// evaluation information end
+
+function basic_expression_001_F($__taint_src) {
+    $a = $__taint_src;
+    $a = "safe";
+    __taint_sink($a);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+basic_expression_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/basic_expression_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/basic_expression_001_T.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = 赋值表达式传递污点
+// level = 1
+// bind_url = completeness/single_app_tracing/expression/basic_expression_001_T
+// evaluation information end
+
+function basic_expression_001_T($__taint_src) {
+    $a = $__taint_src;
+    $b = $a;
+    __taint_sink($b);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+basic_expression_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/basic_expression_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/basic_expression_002_F.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = 复合赋值但最终覆盖安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/basic_expression_002_F
+// evaluation information end
+
+function basic_expression_002_F($__taint_src) {
+    $result = $__taint_src;
+    $result = "overwritten_safe";
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+basic_expression_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/basic_expression_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/basic_expression_002_T.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = 复合赋值运算符 .= 拼接污点
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/basic_expression_002_T
+// evaluation information end
+
+function basic_expression_002_T($__taint_src) {
+    $result = "prefix";
+    $result .= $__taint_src;
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+basic_expression_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/conditional_expression_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/conditional_expression_001_F.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = 三元表达式两侧都是安全值
+// level = 1
+// bind_url = completeness/single_app_tracing/expression/conditional_expression_001_F
+// evaluation information end
+
+function conditional_expression_001_F($__taint_src) {
+    $result = true ? "safe_a" : "safe_b";
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+conditional_expression_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/conditional_expression_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/conditional_expression_001_T.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = 三元表达式 true 分支传递污点
+// level = 1
+// bind_url = completeness/single_app_tracing/expression/conditional_expression_001_T
+// evaluation information end
+
+function conditional_expression_001_T($__taint_src) {
+    $result = true ? $__taint_src : "safe";
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+conditional_expression_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/conditional_expression_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/conditional_expression_002_F.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = null 合并运算符 ?? 两侧都是安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/conditional_expression_002_F
+// evaluation information end
+
+function conditional_expression_002_F($__taint_src) {
+    $val = null;
+    $result = $val ?? "safe_default";
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+conditional_expression_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/conditional_expression_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/conditional_expression_002_T.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = null 合并运算符 ?? 左侧为污点
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/conditional_expression_002_T
+// evaluation information end
+
+function conditional_expression_002_T($__taint_src) {
+    $result = $__taint_src ?? "default_safe";
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+conditional_expression_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/destructuring_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/destructuring_001_F.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = list() 解构取到安全值，污点未传入 sink
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/destructuring_001_F
+// evaluation information end
+
+function destructuring_001_F($__taint_src) {
+    $arr = ["safe", $__taint_src];
+    list($a, $b) = $arr;
+    __taint_sink($a);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+destructuring_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/destructuring_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/destructuring_001_T.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = list() 解构，污染值被解出传入 sink
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/destructuring_001_T
+// evaluation information end
+
+function destructuring_001_T($__taint_src) {
+    $arr = [$__taint_src, "safe"];
+    list($a, $b) = $arr;
+    __taint_sink($a);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+destructuring_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/destructuring_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/destructuring_002_F.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = 嵌套解构取安全部分，污点未传入 sink
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/destructuring_002_F
+// evaluation information end
+
+function destructuring_002_F($__taint_src) {
+    $arr = [["safe", "clean"], [$__taint_src, "dirty"]];
+    [[$a, $b], $rest] = $arr;
+    __taint_sink($a);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+destructuring_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/destructuring_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/destructuring_002_T.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = 短语法 [$a, $b] = $arr 解构传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/destructuring_002_T
+// evaluation information end
+
+function destructuring_002_T($__taint_src) {
+    $arr = ["safe", $__taint_src];
+    [$a, $b] = $arr;
+    __taint_sink($b);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+destructuring_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/heredoc_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/heredoc_001_F.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = nowdoc 不插值，变量名作为字面量不携带污点
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/heredoc_001_F
+// evaluation information end
+
+function heredoc_001_F($__taint_src) {
+    $str = <<<'EOT'
+command: $__taint_src
+EOT;
+    __taint_sink($str);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+heredoc_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/heredoc_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/heredoc_001_T.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = heredoc 内插入污染变量，污点传递到 sink
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/heredoc_001_T
+// evaluation information end
+
+function heredoc_001_T($__taint_src) {
+    $str = <<<EOT
+command: $__taint_src
+EOT;
+    __taint_sink($str);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+heredoc_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/heredoc_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/heredoc_002_F.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = heredoc 仅包含安全字面量，无污点传递
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/heredoc_002_F
+// evaluation information end
+
+function heredoc_002_F($__taint_src) {
+    $safe = "clean_value";
+    $str = <<<EOT
+result: {$safe}
+EOT;
+    __taint_sink($str);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+heredoc_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/heredoc_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/heredoc_002_T.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = heredoc 内使用花括号语法插入污染变量
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/heredoc_002_T
+// evaluation information end
+
+function heredoc_002_T($__taint_src) {
+    $str = <<<EOT
+result: {$__taint_src}
+EOT;
+    __taint_sink($str);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+heredoc_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/nullsafe_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/nullsafe_001_F.php
@@ -1,0 +1,31 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = nullsafe 链返回 null，sink 不接收污染值
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/nullsafe_001_F
+// evaluation information end
+
+class DataHolder {
+    private $data;
+    public function __construct($data) {
+        $this->data = $data;
+    }
+    public function getData() {
+        return $this->data;
+    }
+}
+
+function nullsafe_001_F($__taint_src) {
+    $obj = null;
+    $result = $obj?->getData();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+nullsafe_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/nullsafe_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/nullsafe_001_T.php
@@ -1,0 +1,31 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = nullsafe 运算符 ?-> 返回污染值传入 sink
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/nullsafe_001_T
+// evaluation information end
+
+class DataHolder {
+    private $data;
+    public function __construct($data) {
+        $this->data = $data;
+    }
+    public function getData() {
+        return $this->data;
+    }
+}
+
+function nullsafe_001_T($__taint_src) {
+    $obj = new DataHolder($__taint_src);
+    $result = $obj?->getData();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+nullsafe_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/nullsafe_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/nullsafe_002_F.php
@@ -1,0 +1,41 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = 链式 nullsafe 中间 null 打断链路，sink 接收 null
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/nullsafe_002_F
+// evaluation information end
+
+class Inner {
+    private $value;
+    public function __construct($value) {
+        $this->value = $value;
+    }
+    public function getValue() {
+        return $this->value;
+    }
+}
+
+class Outer {
+    private $inner;
+    public function __construct($inner) {
+        $this->inner = $inner;
+    }
+    public function getInner() {
+        return $this->inner;
+    }
+}
+
+function nullsafe_002_F($__taint_src) {
+    $obj = new Outer(null);
+    $result = $obj?->getInner()?->getValue();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+nullsafe_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/nullsafe_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/nullsafe_002_T.php
@@ -1,0 +1,42 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = 链式 nullsafe $obj?->getInner()?->getValue() 传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/nullsafe_002_T
+// evaluation information end
+
+class Inner {
+    private $value;
+    public function __construct($value) {
+        $this->value = $value;
+    }
+    public function getValue() {
+        return $this->value;
+    }
+}
+
+class Outer {
+    private $inner;
+    public function __construct($inner) {
+        $this->inner = $inner;
+    }
+    public function getInner() {
+        return $this->inner;
+    }
+}
+
+function nullsafe_002_T($__taint_src) {
+    $inner = new Inner($__taint_src);
+    $obj = new Outer($inner);
+    $result = $obj?->getInner()?->getValue();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+nullsafe_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/spread_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/spread_001_F.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = ...$args 展开后 sink 接收的是安全参数
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/spread_001_F
+// evaluation information end
+
+function execute($safe, $tainted) {
+    __taint_sink($safe);
+}
+
+function spread_001_F($__taint_src) {
+    $args = ["safe_value", $__taint_src];
+    execute(...$args);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+spread_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/spread_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/spread_001_T.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = ...$args 展开含污染的数组作为函数参数
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/spread_001_T
+// evaluation information end
+
+function execute($cmd) {
+    __taint_sink($cmd);
+}
+
+function spread_001_T($__taint_src) {
+    $args = [$__taint_src];
+    execute(...$args);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+spread_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/spread_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/spread_002_F.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = 数组解包后取安全部分，污点未传入 sink
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/spread_002_F
+// evaluation information end
+
+function spread_002_F($__taint_src) {
+    $arr1 = ["safe"];
+    $arr2 = [$__taint_src];
+    $merged = [...$arr1, ...$arr2];
+    __taint_sink($merged[0]);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+spread_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/spread_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/spread_002_T.php
@@ -1,0 +1,22 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = 数组解包 [...$arr1, ...$arr2] 传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/spread_002_T
+// evaluation information end
+
+function spread_002_T($__taint_src) {
+    $arr1 = ["safe"];
+    $arr2 = [$__taint_src];
+    $merged = [...$arr1, ...$arr2];
+    __taint_sink($merged[1]);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+spread_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/string_func_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/string_func_001_F.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = sprintf 只使用安全值，无污点传递
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/string_func_001_F
+// evaluation information end
+
+function string_func_001_F($__taint_src) {
+    $safe = "clean_value";
+    $result = sprintf('%s', $safe);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+string_func_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/string_func_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/string_func_001_T.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = sprintf 格式化传递污点到 sink
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/string_func_001_T
+// evaluation information end
+
+function string_func_001_T($__taint_src) {
+    $result = sprintf('%s', $__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+string_func_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/string_func_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/string_func_002_F.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = str_replace 将污染部分替换为安全值，污点被清除
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/string_func_002_F
+// evaluation information end
+
+function string_func_002_F($__taint_src) {
+    $result = str_replace($__taint_src, "safe_value", $__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+string_func_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/string_func_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/string_func_002_T.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = implode 将含污染元素的数组拼接，污点传递到 sink
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/string_func_002_T
+// evaluation information end
+
+function string_func_002_T($__taint_src) {
+    $result = implode(',', [$__taint_src]);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+string_func_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/string_interpolation_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/string_interpolation_001_F.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = 字符串插值但插入的是安全常量
+// level = 1
+// bind_url = completeness/single_app_tracing/expression/string_interpolation_001_F
+// evaluation information end
+
+function string_interpolation_001_F($__taint_src) {
+    $safe = "safe_value";
+    $result = "cmd: $safe";
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+string_interpolation_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/string_interpolation_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/string_interpolation_001_T.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = 双引号字符串插值传递污点
+// level = 1
+// bind_url = completeness/single_app_tracing/expression/string_interpolation_001_T
+// evaluation information end
+
+function string_interpolation_001_T($__taint_src) {
+    $result = "cmd: $__taint_src";
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+string_interpolation_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/string_interpolation_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/string_interpolation_002_F.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = 单引号字符串不插值，变量名作为字面量
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/string_interpolation_002_F
+// evaluation information end
+
+function string_interpolation_002_F($__taint_src) {
+    $result = 'literal: $__taint_src';
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+string_interpolation_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/string_interpolation_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/string_interpolation_002_T.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = 花括号语法字符串插值传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/string_interpolation_002_T
+// evaluation information end
+
+function string_interpolation_002_T($__taint_src) {
+    $result = "execute: {$__taint_src}";
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+string_interpolation_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/type_cast_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/type_cast_001_F.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = (int) 类型转换将字符串转为整数，污点语义丢失
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/type_cast_001_F
+// evaluation information end
+
+function type_cast_001_F($__taint_src) {
+    $result = (int)$__taint_src;
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+type_cast_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/expression/type_cast_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/expression/type_cast_001_T.php
@@ -1,0 +1,20 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->表达式
+// scene introduction = (string) 类型转换保留污点
+// level = 2
+// bind_url = completeness/single_app_tracing/expression/type_cast_001_T
+// evaluation information end
+
+function type_cast_001_T($__taint_src) {
+    $result = (string)$__taint_src;
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+type_cast_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/anonymous_function_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/anonymous_function_001_F.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 匿名函数内返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/anonymous_function_001_F
+// evaluation information end
+
+function anonymous_function_001_F($__taint_src) {
+    $fn = function($data) {
+        return "safe_output";
+    };
+    $result = $fn($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+anonymous_function_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/anonymous_function_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/anonymous_function_001_T.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 匿名函数（闭包）传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/anonymous_function_001_T
+// evaluation information end
+
+function anonymous_function_001_T($__taint_src) {
+    $fn = function($data) {
+        return $data;
+    };
+    $result = $fn($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+anonymous_function_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/anonymous_function_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/anonymous_function_002_F.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 箭头函数返回安全常量
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/anonymous_function_002_F
+// evaluation information end
+
+function anonymous_function_002_F($__taint_src) {
+    $fn = fn($data) => "safe_value";
+    $result = $fn($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+anonymous_function_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/anonymous_function_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/anonymous_function_002_T.php
@@ -1,0 +1,21 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 箭头函数 fn() => 传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/anonymous_function_002_T
+// evaluation information end
+
+function anonymous_function_002_T($__taint_src) {
+    $fn = fn($data) => $data;
+    $result = $fn($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+anonymous_function_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/argument_passing_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/argument_passing_001_F.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 函数参数被净化后传递
+// level = 1
+// bind_url = completeness/single_app_tracing/function_call/argument_passing_001_F
+// evaluation information end
+
+function argument_passing_001_F($__taint_src) {
+    $safe = sanitize($__taint_src);
+    __taint_sink($safe);
+}
+
+function sanitize($data) {
+    return "sanitized";
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+argument_passing_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/argument_passing_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/argument_passing_001_T.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 函数参数直接传递污点
+// level = 1
+// bind_url = completeness/single_app_tracing/function_call/argument_passing_001_T
+// evaluation information end
+
+function argument_passing_001_T($__taint_src) {
+    passToSink($__taint_src);
+}
+
+function passToSink($data) {
+    __taint_sink($data);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+argument_passing_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/argument_passing_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/argument_passing_002_F.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 引用传参后用安全值覆盖
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/argument_passing_002_F
+// evaluation information end
+
+function argument_passing_002_F($__taint_src) {
+    $result = $__taint_src;
+    cleanRef($result);
+    __taint_sink($result);
+}
+
+function cleanRef(&$target) {
+    $target = "cleaned";
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+argument_passing_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/argument_passing_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/argument_passing_002_T.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 引用传参 &$param 修改外部变量传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/argument_passing_002_T
+// evaluation information end
+
+function argument_passing_002_T($__taint_src) {
+    $result = "safe";
+    setTaint($result, $__taint_src);
+    __taint_sink($result);
+}
+
+function setTaint(&$target, $source) {
+    $target = $source;
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+argument_passing_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/argument_passing_003_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/argument_passing_003_F.php
@@ -1,0 +1,28 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 多层函数调用中间层净化了污点
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/argument_passing_003_F
+// evaluation information end
+
+function argument_passing_003_F($__taint_src) {
+    $result = layer1($__taint_src);
+    __taint_sink($result);
+}
+
+function layer1($data) {
+    return layer2($data);
+}
+
+function layer2($data) {
+    return "safe_output";
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+argument_passing_003_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/argument_passing_003_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/argument_passing_003_T.php
@@ -1,0 +1,28 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 多层函数调用传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/argument_passing_003_T
+// evaluation information end
+
+function argument_passing_003_T($__taint_src) {
+    $result = level1($__taint_src);
+    __taint_sink($result);
+}
+
+function level1($data) {
+    return level2($data);
+}
+
+function level2($data) {
+    return $data;
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+argument_passing_003_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/chained_call_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/chained_call_001_F.php
@@ -1,0 +1,39 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 链式调用中间环节净化污点
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/chained_call_001_F
+// evaluation information end
+
+class SafeBuilder {
+    private $data = "";
+
+    public function setData($val) {
+        $this->data = $val;
+        return $this;
+    }
+
+    public function sanitize() {
+        $this->data = "safe";
+        return $this;
+    }
+
+    public function build() {
+        return $this->data;
+    }
+}
+
+function chained_call_001_F($__taint_src) {
+    $builder = new SafeBuilder();
+    $result = $builder->setData($__taint_src)->sanitize()->build();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+chained_call_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/chained_call_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/chained_call_001_T.php
@@ -1,0 +1,34 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 链式方法调用传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/chained_call_001_T
+// evaluation information end
+
+class Builder {
+    private $data = "";
+
+    public function setData($val) {
+        $this->data = $val;
+        return $this;
+    }
+
+    public function build() {
+        return $this->data;
+    }
+}
+
+function chained_call_001_T($__taint_src) {
+    $builder = new Builder();
+    $result = $builder->setData($__taint_src)->build();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+chained_call_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/chained_call_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/chained_call_002_F.php
@@ -1,0 +1,34 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 链式调用最终输出安全常量
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/chained_call_002_F
+// evaluation information end
+
+class ConstPipeline {
+    private $value = "";
+
+    public function input($val) {
+        $this->value = $val;
+        return $this;
+    }
+
+    public function output() {
+        return "constant_output";
+    }
+}
+
+function chained_call_002_F($__taint_src) {
+    $pipe = new ConstPipeline();
+    $result = $pipe->input($__taint_src)->output();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+chained_call_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/chained_call_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/chained_call_002_T.php
@@ -1,0 +1,38 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 多级链式调用传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/chained_call_002_T
+// evaluation information end
+
+class Pipeline {
+    private $value = "";
+
+    public function input($val) {
+        $this->value = $val;
+        return $this;
+    }
+
+    public function process() {
+        return $this;
+    }
+
+    public function output() {
+        return $this->value;
+    }
+}
+
+function chained_call_002_T($__taint_src) {
+    $pipe = new Pipeline();
+    $result = $pipe->input($__taint_src)->process()->output();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+chained_call_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/first_class_callable_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/first_class_callable_001_F.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = first-class callable 引用但 sink 接收安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/first_class_callable_001_F
+// evaluation information end
+
+function run_command($cmd) {
+    __taint_sink($cmd);
+}
+
+function first_class_callable_001_F($__taint_src) {
+    $fn = run_command(...);
+    $fn("safe_value");
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+first_class_callable_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/first_class_callable_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/first_class_callable_001_T.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = first-class callable 语法获取函数引用并调用，传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/first_class_callable_001_T
+// evaluation information end
+
+function run_command($cmd) {
+    __taint_sink($cmd);
+}
+
+function first_class_callable_001_T($__taint_src) {
+    $fn = run_command(...);
+    $fn($__taint_src);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+first_class_callable_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/first_class_callable_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/first_class_callable_002_F.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = first-class callable 通过 array_map 但输入为安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/first_class_callable_002_F
+// evaluation information end
+
+function wrap($val) {
+    return $val;
+}
+
+function first_class_callable_002_F($__taint_src) {
+    $fn = wrap(...);
+    $results = array_map($fn, ["safe_value"]);
+    __taint_sink($results[0]);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+first_class_callable_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/first_class_callable_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/first_class_callable_002_T.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = first-class callable 通过 array_map 传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/first_class_callable_002_T
+// evaluation information end
+
+function wrap($val) {
+    return $val;
+}
+
+function first_class_callable_002_T($__taint_src) {
+    $fn = wrap(...);
+    $results = array_map($fn, [$__taint_src]);
+    __taint_sink($results[0]);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+first_class_callable_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/generator_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/generator_001_F.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 生成器yield安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/generator_001_F
+// evaluation information end
+
+function safeGenerator($src) {
+    yield "safe_value";
+}
+
+function generator_001_F($__taint_src) {
+    foreach (safeGenerator($__taint_src) as $value) {
+        __taint_sink($value);
+    }
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+generator_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/generator_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/generator_001_T.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 生成器yield传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/generator_001_T
+// evaluation information end
+
+function taintedGenerator($src) {
+    yield $src;
+}
+
+function generator_001_T($__taint_src) {
+    foreach (taintedGenerator($__taint_src) as $value) {
+        __taint_sink($value);
+    }
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+generator_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/generator_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/generator_002_F.php
@@ -1,0 +1,29 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = yield from委托安全生成器
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/generator_002_F
+// evaluation information end
+
+function safeInnerGenerator($src) {
+    yield "safe_value";
+}
+
+function safeOuterGenerator($src) {
+    yield from safeInnerGenerator($src);
+}
+
+function generator_002_F($__taint_src) {
+    foreach (safeOuterGenerator($__taint_src) as $value) {
+        __taint_sink($value);
+    }
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+generator_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/generator_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/generator_002_T.php
@@ -1,0 +1,29 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = yield from委托生成器传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/generator_002_T
+// evaluation information end
+
+function innerGenerator($src) {
+    yield $src;
+}
+
+function outerGenerator($src) {
+    yield from innerGenerator($src);
+}
+
+function generator_002_T($__taint_src) {
+    foreach (outerGenerator($__taint_src) as $value) {
+        __taint_sink($value);
+    }
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+generator_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/higher_order_function_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/higher_order_function_001_F.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = array_map 回调返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/higher_order_function_001_F
+// evaluation information end
+
+function higher_order_function_001_F($__taint_src) {
+    $arr = [$__taint_src];
+    $mapped = array_map(function($item) {
+        return "safe_mapped";
+    }, $arr);
+    __taint_sink($mapped[0]);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+higher_order_function_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/higher_order_function_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/higher_order_function_001_T.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = array_map 高阶函数传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/higher_order_function_001_T
+// evaluation information end
+
+function higher_order_function_001_T($__taint_src) {
+    $arr = [$__taint_src];
+    $mapped = array_map(function($item) {
+        return $item;
+    }, $arr);
+    __taint_sink($mapped[0]);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+higher_order_function_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/higher_order_function_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/higher_order_function_002_F.php
@@ -1,0 +1,23 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = usort 回调仅用于比较，sink 接收安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/higher_order_function_002_F
+// evaluation information end
+
+function higher_order_function_002_F($__taint_src) {
+    $arr = ["b", "a", "c"];
+    usort($arr, function($a, $b) {
+        return strcmp($a, $b);
+    });
+    __taint_sink($arr[0]);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+higher_order_function_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/higher_order_function_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/higher_order_function_002_T.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = array_filter 回调保留污点元素
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/higher_order_function_002_T
+// evaluation information end
+
+function higher_order_function_002_T($__taint_src) {
+    $arr = [$__taint_src, "safe"];
+    $filtered = array_filter($arr, function($item) {
+        return strlen($item) > 0;
+    });
+    $result = reset($filtered);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+higher_order_function_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/named_arg_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/named_arg_001_F.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = named arguments 中 sink 使用的参数为安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/named_arg_001_F
+// evaluation information end
+
+function process(string $cmd, string $mode) {
+    return $cmd;
+}
+
+function named_arg_001_F($__taint_src) {
+    $result = process(cmd: "safe_value", mode: $__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+named_arg_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/named_arg_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/named_arg_001_T.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = PHP 8 named arguments 传递污点到 sink
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/named_arg_001_T
+// evaluation information end
+
+function process(string $cmd, string $mode) {
+    return $cmd;
+}
+
+function named_arg_001_T($__taint_src) {
+    $result = process(cmd: $__taint_src, mode: "default");
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+named_arg_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/named_arg_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/named_arg_002_F.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = named arguments 乱序传递，sink 使用安全参数
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/named_arg_002_F
+// evaluation information end
+
+function execute(string $mode, string $cmd) {
+    return $mode;
+}
+
+function named_arg_002_F($__taint_src) {
+    $result = execute(cmd: $__taint_src, mode: "safe_value");
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+named_arg_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/named_arg_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/named_arg_002_T.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = named arguments 乱序传递，污点通过参数名绑定传入 sink
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/named_arg_002_T
+// evaluation information end
+
+function execute(string $mode, string $cmd) {
+    return $cmd;
+}
+
+function named_arg_002_T($__taint_src) {
+    $result = execute(cmd: $__taint_src, mode: "default");
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+named_arg_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/return_value_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/return_value_001_F.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 函数返回安全常量
+// level = 1
+// bind_url = completeness/single_app_tracing/function_call/return_value_001_F
+// evaluation information end
+
+function return_value_001_F($__taint_src) {
+    $result = getSafe($__taint_src);
+    __taint_sink($result);
+}
+
+function getSafe($data) {
+    return "safe_constant";
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+return_value_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/return_value_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/return_value_001_T.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 函数返回值传递污点
+// level = 1
+// bind_url = completeness/single_app_tracing/function_call/return_value_001_T
+// evaluation information end
+
+function return_value_001_T($__taint_src) {
+    $result = getInput($__taint_src);
+    __taint_sink($result);
+}
+
+function getInput($data) {
+    return $data;
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+return_value_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/return_value_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/return_value_002_F.php
@@ -1,0 +1,28 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 嵌套函数中间层返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/return_value_002_F
+// evaluation information end
+
+function return_value_002_F($__taint_src) {
+    $result = outerFn(innerFn($__taint_src));
+    __taint_sink($result);
+}
+
+function outerFn($data) {
+    return $data;
+}
+
+function innerFn($data) {
+    return "safe_inner";
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+return_value_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/return_value_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/return_value_002_T.php
@@ -1,0 +1,28 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 嵌套函数返回值链传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/return_value_002_T
+// evaluation information end
+
+function return_value_002_T($__taint_src) {
+    $result = wrapA(wrapB($__taint_src));
+    __taint_sink($result);
+}
+
+function wrapA($data) {
+    return $data;
+}
+
+function wrapB($data) {
+    return $data;
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+return_value_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/static_method_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/static_method_001_F.php
@@ -1,0 +1,26 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 静态方法返回安全常量
+// level = 1
+// bind_url = completeness/single_app_tracing/function_call/static_method_001_F
+// evaluation information end
+
+class SafeProcessor {
+    public static function process($data) {
+        return "safe_result";
+    }
+}
+
+function static_method_001_F($__taint_src) {
+    $result = SafeProcessor::process($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+static_method_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/static_method_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/static_method_001_T.php
@@ -1,0 +1,26 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 静态方法调用传递污点
+// level = 1
+// bind_url = completeness/single_app_tracing/function_call/static_method_001_T
+// evaluation information end
+
+class Processor {
+    public static function process($data) {
+        return $data;
+    }
+}
+
+function static_method_001_T($__taint_src) {
+    $result = Processor::process($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+static_method_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/static_method_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/static_method_002_F.php
@@ -1,0 +1,26 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 静态方法中净化后返回
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/static_method_002_F
+// evaluation information end
+
+class Sanitizer {
+    public static function clean($data) {
+        return "cleaned_" . strlen($data);
+    }
+}
+
+function static_method_002_F($__taint_src) {
+    $result = Sanitizer::clean($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+static_method_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/static_method_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/static_method_002_T.php
@@ -1,0 +1,33 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 静态属性存储后静态方法读取传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/static_method_002_T
+// evaluation information end
+
+class Registry {
+    private static $value = "";
+
+    public static function set($data) {
+        self::$value = $data;
+    }
+
+    public static function get() {
+        return self::$value;
+    }
+}
+
+function static_method_002_T($__taint_src) {
+    Registry::set($__taint_src);
+    $result = Registry::get();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+static_method_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/variable_function_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/variable_function_001_F.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 可变函数调用但函数返回安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/variable_function_001_F
+// evaluation information end
+
+function getSafeValue($data) {
+    return "safe";
+}
+
+function variable_function_001_F($__taint_src) {
+    $func = 'getSafeValue';
+    $result = $func($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+variable_function_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/variable_function_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/variable_function_001_T.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = 可变函数 $func() 传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/variable_function_001_T
+// evaluation information end
+
+function passThrough($data) {
+    return $data;
+}
+
+function variable_function_001_T($__taint_src) {
+    $func = 'passThrough';
+    $result = $func($__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+variable_function_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/variable_function_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/variable_function_002_F.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = call_user_func 调用净化函数
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/variable_function_002_F
+// evaluation information end
+
+function cleanData($data) {
+    return "cleaned";
+}
+
+function variable_function_002_F($__taint_src) {
+    $result = call_user_func('cleanData', $__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+variable_function_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/function_call/variable_function_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/function_call/variable_function_002_T.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->函数调用
+// scene introduction = call_user_func 动态调用传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/function_call/variable_function_002_T
+// evaluation information end
+
+function identity($data) {
+    return $data;
+}
+
+function variable_function_002_T($__taint_src) {
+    $result = call_user_func('identity', $__taint_src);
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+variable_function_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/variable_scope/closure_use_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/variable_scope/closure_use_001_F.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->变量作用域
+// scene introduction = 闭包 use 捕获值但返回安全常量
+// level = 2
+// bind_url = completeness/single_app_tracing/variable_scope/closure_use_001_F
+// evaluation information end
+
+function closure_use_001_F($__taint_src) {
+    $tainted = $__taint_src;
+    $fn = function() use ($tainted) {
+        return "safe_closure_result";
+    };
+    $result = $fn();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+closure_use_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/variable_scope/closure_use_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/variable_scope/closure_use_001_T.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->变量作用域
+// scene introduction = 闭包 use ($var) 捕获外部污点变量
+// level = 2
+// bind_url = completeness/single_app_tracing/variable_scope/closure_use_001_T
+// evaluation information end
+
+function closure_use_001_T($__taint_src) {
+    $tainted = $__taint_src;
+    $fn = function() use ($tainted) {
+        return $tainted;
+    };
+    $result = $fn();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+closure_use_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/variable_scope/closure_use_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/variable_scope/closure_use_002_F.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->变量作用域
+// scene introduction = 闭包 use (&$var) 引用捕获后设为安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/variable_scope/closure_use_002_F
+// evaluation information end
+
+function closure_use_002_F($__taint_src) {
+    $result = $__taint_src;
+    $fn = function() use (&$result) {
+        $result = "safe_overwrite";
+    };
+    $fn();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+closure_use_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/variable_scope/closure_use_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/variable_scope/closure_use_002_T.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->变量作用域
+// scene introduction = 闭包 use (&$var) 引用捕获修改外部变量传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/variable_scope/closure_use_002_T
+// evaluation information end
+
+function closure_use_002_T($__taint_src) {
+    $result = "safe";
+    $fn = function() use (&$result, $__taint_src) {
+        $result = $__taint_src;
+    };
+    $fn();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+closure_use_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/variable_scope/global_variable_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/variable_scope/global_variable_001_F.php
@@ -1,0 +1,29 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->变量作用域
+// scene introduction = 全局变量被安全值覆盖
+// level = 2
+// bind_url = completeness/single_app_tracing/variable_scope/global_variable_001_F
+// evaluation information end
+
+$globalData = "";
+
+function setGlobalSafe($data) {
+    global $globalData;
+    $globalData = $data;
+    $globalData = "safe_global";
+}
+
+function global_variable_001_F($__taint_src) {
+    global $globalData;
+    setGlobalSafe($__taint_src);
+    __taint_sink($globalData);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+global_variable_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/variable_scope/global_variable_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/variable_scope/global_variable_001_T.php
@@ -1,0 +1,28 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->变量作用域
+// scene introduction = global 关键字引入全局变量传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/variable_scope/global_variable_001_T
+// evaluation information end
+
+$globalTaint = "";
+
+function setGlobal($data) {
+    global $globalTaint;
+    $globalTaint = $data;
+}
+
+function global_variable_001_T($__taint_src) {
+    global $globalTaint;
+    setGlobal($__taint_src);
+    __taint_sink($globalTaint);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+global_variable_001_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/variable_scope/global_variable_002_F.php
+++ b/sast-php/case/completeness/single_app_tracing/variable_scope/global_variable_002_F.php
@@ -1,0 +1,25 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->变量作用域
+// scene introduction = $GLOBALS 写入后被覆盖为安全值
+// level = 2
+// bind_url = completeness/single_app_tracing/variable_scope/global_variable_002_F
+// evaluation information end
+
+function writeGlobals($data) {
+    $GLOBALS['sharedData'] = $data;
+}
+
+function global_variable_002_F($__taint_src) {
+    writeGlobals($__taint_src);
+    $GLOBALS['sharedData'] = "safe_overwrite";
+    __taint_sink($GLOBALS['sharedData']);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+global_variable_002_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/variable_scope/global_variable_002_T.php
+++ b/sast-php/case/completeness/single_app_tracing/variable_scope/global_variable_002_T.php
@@ -1,0 +1,24 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->变量作用域
+// scene introduction = $GLOBALS 超全局数组传递污点
+// level = 2
+// bind_url = completeness/single_app_tracing/variable_scope/global_variable_002_T
+// evaluation information end
+
+function setViaGlobals($data) {
+    $GLOBALS['taintData'] = $data;
+}
+
+function global_variable_002_T($__taint_src) {
+    setViaGlobals($__taint_src);
+    __taint_sink($GLOBALS['taintData']);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+global_variable_002_T($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/variable_scope/static_variable_001_F.php
+++ b/sast-php/case/completeness/single_app_tracing/variable_scope/static_variable_001_F.php
@@ -1,0 +1,30 @@
+<?php
+// evaluation information start
+// real case = false
+// evaluation item = 完整度->单应用追踪->变量作用域
+// scene introduction = 静态变量被安全值覆盖后读取
+// level = 2
+// bind_url = completeness/single_app_tracing/variable_scope/static_variable_001_F
+// evaluation information end
+
+function staticStore($data = null) {
+    static $cache = "";
+    if ($data !== null) {
+        $cache = $data;
+    }
+    return $cache;
+}
+
+function static_variable_001_F($__taint_src) {
+    staticStore($__taint_src);
+    staticStore("safe_overwrite");
+    $result = staticStore();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+static_variable_001_F($taint_src);

--- a/sast-php/case/completeness/single_app_tracing/variable_scope/static_variable_001_T.php
+++ b/sast-php/case/completeness/single_app_tracing/variable_scope/static_variable_001_T.php
@@ -1,0 +1,29 @@
+<?php
+// evaluation information start
+// real case = true
+// evaluation item = 完整度->单应用追踪->变量作用域
+// scene introduction = 静态变量跨调用保留污点
+// level = 2
+// bind_url = completeness/single_app_tracing/variable_scope/static_variable_001_T
+// evaluation information end
+
+function storeStatic($data = null) {
+    static $stored = "";
+    if ($data !== null) {
+        $stored = $data;
+    }
+    return $stored;
+}
+
+function static_variable_001_T($__taint_src) {
+    storeStatic($__taint_src);
+    $result = storeStatic();
+    __taint_sink($result);
+}
+
+function __taint_sink($o) {
+    shell_exec($o);
+}
+
+$taint_src = "taint_src_value";
+static_variable_001_T($taint_src);


### PR DESCRIPTION
覆盖 accuracy（准确度）和 completeness（完整度）两大维度共 63 个评价项：
- accuracy: 13 子维度 64 case（上下文敏感/路径敏感/流敏感/对象域敏感）
- completeness/single_app_tracing: 47 子维度 214 case（别名/控制流/跨文件/数据类型/异常/表达式/函数调用/OOP/变量作用域）
- completeness/dynamic_tracing: 3 子维度 12 case（eval/可变变量/compact-extract）

PHP 特有语法全覆盖：引用赋值、魔术方法、trait、闭包use、match、nullsafe、
heredoc、spread、解构、named args、enum、readonly、generator、超全局变量、 autoload、可变函数、late static binding、匿名类、first-class callable 等。

全部 290 文件通过 php -l 语法校验（PHP 8.5.4）。