### PR TITLE
fix: unify __taint_sink parameter name to 'o' (was mixing 'data')

### DIFF
--- a/sast-js/case/completeness/single_app_tracing/function_call/override/constructor_extends_003_T.js
+++ b/sast-js/case/completeness/single_app_tracing/function_call/override/constructor_extends_003_T.js
@@ -34,8 +34,8 @@ function constructor_extends_003_T(__taint_src) {
   derived.process();
 }
 
-function __taint_sink(data) {
-    execSync(data);
+function __taint_sink(o) {
+    execSync(o);
 }
 
 const taint_src = "taint_src_value";

--- a/sast-js/case/completeness/single_app_tracing/function_call/override/constructor_extends_004_F.js
+++ b/sast-js/case/completeness/single_app_tracing/function_call/override/constructor_extends_004_F.js
@@ -34,8 +34,8 @@ function constructor_extends_004_F(__taint_src) {
   derived.process();
 }
 
-function __taint_sink(data) {
- execSync(data);
+function __taint_sink(o) {
+ execSync(o);
 }
 
 const taint_src = "taint_src_value";

--- a/sast-js/case/completeness/single_app_tracing/interface_class/complex_object/cross_class_003_T.js
+++ b/sast-js/case/completeness/single_app_tracing/interface_class/complex_object/cross_class_003_T.js
@@ -36,8 +36,8 @@ function cross_class_003_T(__taint_src) {
   __taint_sink(a);
 }
 
-function __taint_sink(data) {
-  execSync(JSON.stringify(data));
+function __taint_sink(o) {
+  execSync(JSON.stringify(o));
 }
 
 const taint_src = "taint_src_value";

--- a/sast-js/case/completeness/single_app_tracing/interface_class/complex_object/cross_class_004_F.js
+++ b/sast-js/case/completeness/single_app_tracing/interface_class/complex_object/cross_class_004_F.js
@@ -36,8 +36,8 @@ function cross_class_004_F(__taint_src) {
   __taint_sink(a);
 }
 
-function __taint_sink(data) {
-  execSync(JSON.stringify(data));
+function __taint_sink(o) {
+  execSync(JSON.stringify(o));
 }
 
 const taint_src = "taint_src_value";

--- a/sast-js/case/completeness/single_app_tracing/interface_class/complex_object/cross_class_005_T.js
+++ b/sast-js/case/completeness/single_app_tracing/interface_class/complex_object/cross_class_005_T.js
@@ -17,8 +17,8 @@ function cross_class_005_T(__taint_src) {
   __taint_sink(a.b.c);
 }
 
-function __taint_sink(data) {
-  execSync(JSON.stringify(data));
+function __taint_sink(o) {
+  execSync(JSON.stringify(o));
 }
 
 const taint_src = "taint_src_value";

--- a/sast-js/case/completeness/single_app_tracing/interface_class/complex_object/cross_class_006_F.js
+++ b/sast-js/case/completeness/single_app_tracing/interface_class/complex_object/cross_class_006_F.js
@@ -17,8 +17,8 @@ function cross_class_006_F(__taint_src) {
   __taint_sink(a.b.c);
 }
 
-function __taint_sink(data) {
-  execSync(JSON.stringify(data));
+function __taint_sink(o) {
+  execSync(JSON.stringify(o));
 }
 
 const taint_src = "taint_src_value";

--- a/sast-js/case/completeness/single_app_tracing/interface_class/complex_object/cross_class_007_T.js
+++ b/sast-js/case/completeness/single_app_tracing/interface_class/complex_object/cross_class_007_T.js
@@ -20,8 +20,8 @@ function cross_class_007_T(__taint_src) {
   __taint_sink(a.b.c);
 }
 
-function __taint_sink(data) {
-  execSync(JSON.stringify(data));
+function __taint_sink(o) {
+  execSync(JSON.stringify(o));
 }
 
 const taint_src = "taint_src_value";

--- a/sast-js/case/completeness/single_app_tracing/interface_class/complex_object/cross_class_008_F.js
+++ b/sast-js/case/completeness/single_app_tracing/interface_class/complex_object/cross_class_008_F.js
@@ -20,8 +20,8 @@ function cross_class_008_F(__taint_src) {
   __taint_sink(a.b.c);
 }
 
-function __taint_sink(data) {
-  execSync(JSON.stringify(data));
+function __taint_sink(o) {
+  execSync(JSON.stringify(o));
 }
 
 const taint_src = "taint_src_value";

--- a/sast-python2/case/completeness/single_app_tracing/function_call/override/constructor_extends_003_T.py
+++ b/sast-python2/case/completeness/single_app_tracing/function_call/override/constructor_extends_003_T.py
@@ -33,8 +33,8 @@ def constructor_extends_003_T(taint_src):
 
 
 
-def taint_sink(data):
-    os.system(data)
+def taint_sink(o):
+    os.system(o)
 
 
 if __name__ == u'__main__':

--- a/sast-python2/case/completeness/single_app_tracing/function_call/override/constructor_extends_004_F.py
+++ b/sast-python2/case/completeness/single_app_tracing/function_call/override/constructor_extends_004_F.py
@@ -33,8 +33,8 @@ def constructor_extends_004_F(taint_src):
 
 
 
-def taint_sink(data):
-    os.system(data)
+def taint_sink(o):
+    os.system(o)
 
 
 if __name__ == u'__main__':

--- a/sast-python3/case/completeness/single_app_tracing/function_call/override/constructor_extends_003_T.py
+++ b/sast-python3/case/completeness/single_app_tracing/function_call/override/constructor_extends_003_T.py
@@ -33,8 +33,8 @@ def constructor_extends_003_T(taint_src):
 
 
 
-def taint_sink(data):
-    os.system(data)
+def taint_sink(o):
+    os.system(o)
 
 
 if __name__ == '__main__':

--- a/sast-python3/case/completeness/single_app_tracing/function_call/override/constructor_extends_004_F.py
+++ b/sast-python3/case/completeness/single_app_tracing/function_call/override/constructor_extends_004_F.py
@@ -33,8 +33,8 @@ def constructor_extends_004_F(taint_src):
 
 
 
-def taint_sink(data):
-    os.system(data)
+def taint_sink(o):
+    os.system(o)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
fix: unify __taint_sink parameter name to 'o' across inconsistent cases

Some test cases used 'data' while the majority used 'o' as the parameter name
for the __taint_sink function. This caused inconsistent behavior when
static analysis tools expect a unified naming pattern.

Unified all occurrences to use 'o' to improve consistency and reduce
false negatives/positives in automated analysis.

Affected files:
- sast-js/.../constructor_extends_003_T.js
- sast-js/.../constructor_extends_004_F.js
- sast-js/.../cross_class_003_T.js
- sast-js/.../cross_class_004_F.js
- sast-js/.../cross_class_005_T.js
- sast-js/.../cross_class_006_F.js
- sast-js/.../cross_class_007_T.js
- sast-js/.../cross_class_008_F.js
- sast-python2/.../constructor_extends_003_T.py
- sast-python2/.../constructor_extends_004_F.py
- sast-python3/.../constructor_extends_003_T.py
- sast-python3/.../constructor_extends_004_F.py